### PR TITLE
Re-add testing tools to the build path

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -4,6 +4,10 @@ members = [
   "metaplex/program",
   "token-vault/program",
   "token-metadata/program",
+  "auction/cli",
+  "metaplex/test",
+  "token-valut/test",
+  "token-metadata/test",
 ]
 exclude = [
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -6,7 +6,7 @@ members = [
   "token-metadata/program",
   "auction/cli",
   "metaplex/test",
-  "token-valut/test",
+  "token-vault/test",
   "token-metadata/test",
 ]
 exclude = [

--- a/rust/auction/cli/src/main.rs
+++ b/rust/auction/cli/src/main.rs
@@ -563,7 +563,7 @@ fn main() {
                 .takes_value(true)
                 .global(true)
                 .validator(is_url)
-                .help("JSON RPC URL for the cluster [default: devnet]"),
+                .help("JSON RPC URL for the cluster [default: testnet]"),
         )
         .subcommand(
             SubCommand::with_name("create")
@@ -1085,7 +1085,7 @@ fn main() {
     let client = RpcClient::new(
         app_matches
             .value_of("json_rpc_url")
-            .unwrap_or(&"https://testnet.solana.com".to_owned())
+            .unwrap_or(&"https://api.testnet.solana.com".to_owned())
             .to_owned(),
     );
 

--- a/rust/metaplex/test/src/main.rs
+++ b/rust/metaplex/test/src/main.rs
@@ -267,7 +267,7 @@ fn main() {
     let client = RpcClient::new(
         app_matches
             .value_of("json_rpc_url")
-            .unwrap_or(&"https://devnet.solana.com".to_owned())
+            .unwrap_or(&"https://api.devnet.solana.com".to_owned())
             .to_owned(),
     );
 

--- a/rust/metaplex/test/src/redeem_bid.rs
+++ b/rust/metaplex/test/src/redeem_bid.rs
@@ -29,7 +29,7 @@ use {
         state::Account,
     },
     spl_token_metadata::state::{MasterEdition, EDITION},
-    spl_token_vault::state::{SafetyDepositBox, Vault, SAFETY_DEPOSIT_KEY},
+    spl_token_vault::state::{SafetyDepositBox, Vault, Key},
     std::{collections::HashMap, str::FromStr},
 };
 
@@ -400,7 +400,7 @@ pub fn redeem_bid_wrapper(app_matches: &ArgMatches, payer: Keypair, client: RpcC
         let obj_key = &acc.0;
         let type_of_obj = obj.data[0];
 
-        if type_of_obj == SAFETY_DEPOSIT_KEY {
+        if type_of_obj == Key::SafetyDepositBoxV1 as u8 {
             let pubkey_arr = array_ref![obj.data, 1, 32];
             let pubkey = Pubkey::new_from_array(*pubkey_arr);
             if pubkey == manager.vault {

--- a/rust/metaplex/test/src/redeem_bid.rs
+++ b/rust/metaplex/test/src/redeem_bid.rs
@@ -29,7 +29,7 @@ use {
         state::Account,
     },
     spl_token_metadata::state::{MasterEdition, EDITION},
-    spl_token_vault::state::{SafetyDepositBox, Vault, Key},
+    spl_token_vault::state::{Key, SafetyDepositBox, Vault},
     std::{collections::HashMap, str::FromStr},
 };
 

--- a/rust/metaplex/test/src/validate_safety_deposits.rs
+++ b/rust/metaplex/test/src/validate_safety_deposits.rs
@@ -15,7 +15,7 @@ use {
         state::{AuctionManager, WinningConfig},
     },
     spl_token_metadata::state::{Key, MasterEdition, EDITION},
-    spl_token_vault::state::{SafetyDepositBox, SAFETY_DEPOSIT_KEY},
+    spl_token_vault::state::{SafetyDepositBox, Key as VaultKey},
     std::{collections::HashMap, str::FromStr},
 };
 
@@ -64,7 +64,7 @@ pub fn validate_safety_deposits(app_matches: &ArgMatches, payer: Keypair, client
         let obj_key = &acc.0;
         let type_of_obj = obj.data[0];
 
-        if type_of_obj == SAFETY_DEPOSIT_KEY {
+        if type_of_obj == VaultKey::SafetyDepositBoxV1 as u8 {
             let pubkey_arr = array_ref![obj.data, 1, 32];
             let pubkey = Pubkey::new_from_array(*pubkey_arr);
             if pubkey == manager.vault {

--- a/rust/metaplex/test/src/validate_safety_deposits.rs
+++ b/rust/metaplex/test/src/validate_safety_deposits.rs
@@ -15,7 +15,7 @@ use {
         state::{AuctionManager, WinningConfig},
     },
     spl_token_metadata::state::{Key, MasterEdition, EDITION},
-    spl_token_vault::state::{SafetyDepositBox, Key as VaultKey},
+    spl_token_vault::state::{Key as VaultKey, SafetyDepositBox},
     std::{collections::HashMap, str::FromStr},
 };
 

--- a/rust/token-metadata/test/src/main.rs
+++ b/rust/token-metadata/test/src/main.rs
@@ -803,7 +803,7 @@ fn main() {
     let client = RpcClient::new(
         app_matches
             .value_of("json_rpc_url")
-            .unwrap_or(&"https://devnet.solana.com".to_owned())
+            .unwrap_or(&"https://api.devnet.solana.com".to_owned())
             .to_owned(),
     );
 

--- a/rust/token-vault/test/src/main.rs
+++ b/rust/token-vault/test/src/main.rs
@@ -1263,7 +1263,7 @@ fn main() {
     let client = RpcClient::new(
         app_matches
             .value_of("json_rpc_url")
-            .unwrap_or(&"https://devnet.solana.com".to_owned())
+            .unwrap_or(&"https://api.devnet.solana.com".to_owned())
             .to_owned(),
     );
 


### PR DESCRIPTION
Added the testing tools back to the build path. 
Also corrected the default RPC URLs, as the outdated ones were being used.

Fix #54