### PR TITLE
Vault unwinder [1/2]

### DIFF
--- a/js/packages/common/src/actions/vault.ts
+++ b/js/packages/common/src/actions/vault.ts
@@ -220,7 +220,7 @@ export const VAULT_SCHEMA = new Map<any, any>([
         ['fractionTreasury', 'pubkey'],
         ['redeemTreasury', 'pubkey'],
         ['allowFurtherShareCreation', 'u8'],
-        ['pricingLookupAddress', 'u8'],
+        ['pricingLookupAddress', 'pubkey'],
         ['tokenTypeCount', 'u8'],
         ['state', 'u8'],
         ['lockedPricePerShare', 'u64'],
@@ -256,6 +256,14 @@ export const VAULT_SCHEMA = new Map<any, any>([
 
 export const decodeVault = (buffer: Buffer) => {
   return deserializeUnchecked(VAULT_SCHEMA, Vault, buffer) as Vault;
+};
+
+export const decodeExternalPriceAccount = (buffer: Buffer) => {
+  return deserializeUnchecked(
+    VAULT_SCHEMA,
+    ExternalPriceAccount,
+    buffer,
+  ) as ExternalPriceAccount;
 };
 
 export const decodeSafetyDeposit = (buffer: Buffer) => {

--- a/js/packages/web/src/actions/closeVault.ts
+++ b/js/packages/web/src/actions/closeVault.ts
@@ -24,6 +24,7 @@ export async function closeVault(
   redeemTreasury: PublicKey,
   priceMint: PublicKey,
   externalPriceAccount: PublicKey,
+  setAuthorityToAuctionManager: boolean,
 ): Promise<{
   instructions: TransactionInstruction[];
   signers: Keypair[];
@@ -116,7 +117,7 @@ export async function closeVault(
     fractionMint,
     fractionTreasury,
     redeemTreasury,
-    auctionManagerKey,
+    setAuthorityToAuctionManager ? auctionManagerKey : wallet.publicKey,
     wallet.publicKey,
     transferAuthority.publicKey,
     externalPriceAccount,

--- a/js/packages/web/src/actions/createAuctionManager.ts
+++ b/js/packages/web/src/actions/createAuctionManager.ts
@@ -211,6 +211,7 @@ export async function createAuctionManager(
       redeemTreasury,
       priceMint,
       externalPriceAccount,
+      true,
     ),
     addTokens: { instructions: addTokenInstructions, signers: addTokenSigners },
     createReservationList: {

--- a/js/packages/web/src/actions/createExternalPriceAccount.ts
+++ b/js/packages/web/src/actions/createExternalPriceAccount.ts
@@ -5,10 +5,10 @@ import {
   SystemProgram,
   TransactionInstruction,
 } from '@solana/web3.js';
-import { utils, actions, createMint } from '@oyster/common';
+import { utils, actions } from '@oyster/common';
 
-import { MintLayout } from '@solana/spl-token';
 import BN from 'bn.js';
+import { QUOTE_MINT } from '../constants';
 const {
   updateExternalPriceAccount,
   ExternalPriceAccount,
@@ -30,29 +30,15 @@ export async function createExternalPriceAccount(
   let signers: Keypair[] = [];
   let instructions: TransactionInstruction[] = [];
 
-  const mintRentExempt = await connection.getMinimumBalanceForRentExemption(
-    MintLayout.span,
-  );
-
   const epaRentExempt = await connection.getMinimumBalanceForRentExemption(
     MAX_EXTERNAL_ACCOUNT_SIZE,
   );
 
   let externalPriceAccount = Keypair.generate();
 
-  const priceMint = createMint(
-    instructions,
-    wallet.publicKey,
-    mintRentExempt,
-    0,
-    wallet.publicKey,
-    wallet.publicKey,
-    signers,
-  );
-
   let epaStruct = new ExternalPriceAccount({
     pricePerShare: new BN(0),
-    priceMint: priceMint,
+    priceMint: QUOTE_MINT,
     allowedToCombine: true,
   });
 
@@ -74,7 +60,7 @@ export async function createExternalPriceAccount(
 
   return {
     externalPriceAccount: externalPriceAccount.publicKey,
-    priceMint,
+    priceMint: QUOTE_MINT,
     instructions,
     signers,
   };

--- a/js/packages/web/src/actions/unwindVault.ts
+++ b/js/packages/web/src/actions/unwindVault.ts
@@ -1,0 +1,140 @@
+import {
+  Keypair,
+  Connection,
+  PublicKey,
+  TransactionInstruction,
+} from '@solana/web3.js';
+import {
+  Vault,
+  ParsedAccount,
+  SafetyDepositBox,
+  programIds,
+  createAssociatedTokenAccountInstruction,
+  withdrawTokenFromSafetyDepositBox,
+  VaultState,
+  sendTransactionsWithManualRetry,
+  decodeExternalPriceAccount,
+} from '@oyster/common';
+
+import BN from 'bn.js';
+import { closeVault } from './closeVault';
+import { QUOTE_MINT } from '../constants';
+
+const BATCH_SIZE = 1;
+
+// Given a vault you own, unwind all the tokens out of it.
+export async function unwindVault(
+  connection: Connection,
+  wallet: any,
+  vault: ParsedAccount<Vault>,
+  safetyDepositBoxesByVaultAndIndex: Record<
+    string,
+    ParsedAccount<SafetyDepositBox>
+  >,
+) {
+  let batchCounter = 0;
+  const PROGRAM_IDS = programIds();
+  let signers: Array<Keypair[]> = [];
+  let instructions: Array<TransactionInstruction[]> = [];
+
+  let currSigners: Keypair[] = [];
+  let currInstructions: TransactionInstruction[] = [];
+
+  if (vault.info.state == VaultState.Inactive) {
+    console.log('Vault is inactive, combining');
+    const epa = await connection.getAccountInfo(
+      vault.info.pricingLookupAddress,
+    );
+    if (epa) {
+      const decoded = decodeExternalPriceAccount(epa.data);
+      // "Closing" it here actually brings it to Combined state which means we can withdraw tokens.
+      let { instructions: cvInstructions, signers: cvSigners } =
+        await closeVault(
+          connection,
+          wallet,
+          vault.pubkey,
+          vault.info.fractionMint,
+          vault.info.fractionTreasury,
+          vault.info.redeemTreasury,
+          decoded.priceMint,
+          vault.info.pricingLookupAddress,
+          false,
+        );
+
+      signers.push(cvSigners);
+      instructions.push(cvInstructions);
+    }
+  }
+
+  const vaultKey = vault.pubkey.toBase58();
+  let boxes: ParsedAccount<SafetyDepositBox>[] = [];
+
+  let box = safetyDepositBoxesByVaultAndIndex[vaultKey + '-0'];
+  if (box) {
+    boxes.push(box);
+    let i = 1;
+    while (box) {
+      box = safetyDepositBoxesByVaultAndIndex[vaultKey + '-' + i.toString()];
+      if (box) boxes.push(box);
+      i++;
+    }
+  }
+  console.log('Found boxes', boxes);
+  for (let i = 0; i < boxes.length; i++) {
+    let nft = boxes[i];
+    const ata = (
+      await PublicKey.findProgramAddress(
+        [
+          wallet.publicKey.toBuffer(),
+          PROGRAM_IDS.token.toBuffer(),
+          nft.info.tokenMint.toBuffer(),
+        ],
+        PROGRAM_IDS.associatedToken,
+      )
+    )[0];
+
+    const existingAta = await connection.getAccountInfo(ata);
+    console.log('Existing ata?', existingAta);
+    if (!existingAta)
+      createAssociatedTokenAccountInstruction(
+        currInstructions,
+        ata,
+        wallet.publicKey,
+        wallet.publicKey,
+        nft.info.tokenMint,
+      );
+
+    const value = await connection.getTokenAccountBalance(nft.info.store);
+    await withdrawTokenFromSafetyDepositBox(
+      new BN(value.value.uiAmount || 1),
+      ata,
+      nft.pubkey,
+      nft.info.store,
+      vault.pubkey,
+      vault.info.fractionMint,
+      vault.info.authority,
+      currInstructions,
+    );
+
+    if (batchCounter === BATCH_SIZE) {
+      signers.push(currSigners);
+      instructions.push(currInstructions);
+      batchCounter = 0;
+      currSigners = [];
+      currInstructions = [];
+    }
+    batchCounter++;
+  }
+
+  if (instructions[instructions.length - 1] !== currInstructions) {
+    signers.push(currSigners);
+    instructions.push(currInstructions);
+  }
+
+  await sendTransactionsWithManualRetry(
+    connection,
+    wallet,
+    instructions,
+    signers,
+  );
+}

--- a/js/packages/web/src/contexts/meta.tsx
+++ b/js/packages/web/src/contexts/meta.tsx
@@ -655,10 +655,7 @@ const processMetaplexAccounts = async (
   try {
     const STORE_ID = programIds().store?.toBase58() || '';
 
-    if (
-      a.account.data[0] === MetaplexKey.AuctionManagerV1 ||
-      a.account.data[0] === 0
-    ) {
+    if (a.account.data[0] === MetaplexKey.AuctionManagerV1) {
       const storeKey = new PublicKey(a.account.data.slice(1, 33));
       if (storeKey.toBase58() === STORE_ID) {
         const auctionManager = decodeAuctionManager(a.account.data);
@@ -755,10 +752,7 @@ const processMetaData = async (
   if (meta.account.owner.toBase58() != programIds().metadata.toBase58()) return;
 
   try {
-    if (
-      meta.account.data[0] === MetadataKey.MetadataV1 ||
-      meta.account.data[0] === 0
-    ) {
+    if (meta.account.data[0] === MetadataKey.MetadataV1) {
       const metadata = await decodeMetadata(meta.account.data);
 
       if (
@@ -831,10 +825,7 @@ const processVaultData = (
         ...e,
         [safetyDeposit.vault.toBase58() + '-' + safetyDeposit.order]: account,
       }));
-    } else if (
-      a.account.data[0] === VaultKey.VaultV1 ||
-      a.account.data[0] === 0
-    ) {
+    } else if (a.account.data[0] === VaultKey.VaultV1) {
       const vault = decodeVault(a.account.data);
       const account: ParsedAccount<Vault> = {
         pubkey: a.pubkey,

--- a/js/packages/web/src/contexts/meta.tsx
+++ b/js/packages/web/src/contexts/meta.tsx
@@ -27,7 +27,6 @@ import {
   Vault,
   setProgramIds,
   useConnectionConfig,
-  useWallet,
   walletAdapters,
   AuctionState,
 } from '@oyster/common';
@@ -115,7 +114,6 @@ const MetaContext = React.createContext<MetaContextState>({
 
 export function MetaProvider({ children = null as any }) {
   const connection = useConnection();
-  const { wallet } = useWallet();
   const { env } = useConnectionConfig();
 
   const [metadata, setMetadata] = useState<ParsedAccount<Metadata>[]>([]);
@@ -230,7 +228,6 @@ export function MetaProvider({ children = null as any }) {
 
         processAuctions(
           accounts[i],
-          wallet,
           (cb: any) => (tempCache.auctions = cb(tempCache.auctions)),
           (cb: any) =>
             (tempCache.bidderMetadataByAuctionAndBidder = cb(
@@ -332,7 +329,6 @@ export function MetaProvider({ children = null as any }) {
     setWhitelistedCreatorsByCreator,
     updateMints,
     env,
-    wallet,
   ]);
 
   useEffect(() => {
@@ -414,7 +410,6 @@ export function MetaProvider({ children = null as any }) {
             pubkey,
             account: info.accountInfo,
           },
-          wallet,
           setAuctions,
           setBidderMetadataByAuctionAndBidder,
           setBidderPotsByAuctionAndBidder,
@@ -584,7 +579,6 @@ function isValidHttpUrl(text: string) {
 
 const processAuctions = (
   a: PublicKeyAndAccount<Buffer>,
-  wallet: any,
   setAuctions: any,
   setBidderMetadataByAuctionAndBidder: any,
   setBidderPotsByAuctionAndBidder: any,


### PR DESCRIPTION
- Removes the checks for structs with key 0 since those don't exist anymore
- Removes unneeded extra mint being created during external price lookup creation process - just use quote mint
- Fix vault serde - had pubkey incorrectly being deserialized as u8
- Add vault unwinding functionality for vaults that are owned by current wallet. This does not cover cases where the vault authority was transferred to auction manager and then auction creation failed after that point. That will require a new rust endpoint to transfer authority back, and will come in a follow up PR.
Partially addresses https://github.com/metaplex-foundation/metaplex/issues/53