### PR TITLE
Remove number "0" being rendered unintentionally

### DIFF
--- a/js/packages/web/src/components/AppBar/index.tsx
+++ b/js/packages/web/src/components/AppBar/index.tsx
@@ -26,9 +26,9 @@ const UserActions = () => {
       {/* <Link to={`#`}>
         <Button className="app-btn">Bids</Button>
       </Link> */}
-      {canCreate && (<Link to={`/art/create`}>
+      {canCreate ? (<Link to={`/art/create`}>
         <Button className="app-btn">Create</Button>
-      </Link>)}
+      </Link>) : null}
       <Link to={`/auction/create/0`}>
         <Button className="connector" type="primary" >Sell</Button>
       </Link>


### PR DESCRIPTION
`canCreate && (<Link...)` evaluates to a fals-ey value and renders as the number "0". The proper way to achieve not showing anything is via a ternary operator.