### PR TITLE
Fix case where it's possible to assign authority to AuctionManager that does not yet exist

### DIFF
--- a/js/packages/common/src/actions/auction.ts
+++ b/js/packages/common/src/actions/auction.ts
@@ -431,6 +431,10 @@ class CancelBidArgs {
   }
 }
 
+class SetAuthorityArgs {
+  instruction: number = 5;
+}
+
 export const AUCTION_SCHEMA = new Map<any, any>([
   [
     CreateAuctionArgs,
@@ -489,6 +493,14 @@ export const AUCTION_SCHEMA = new Map<any, any>([
         ['instruction', 'u8'],
         ['resource', 'pubkey'],
       ],
+    },
+  ],
+
+  [
+    SetAuthorityArgs,
+    {
+      kind: 'struct',
+      fields: [['instruction', 'u8']],
     },
   ],
   [
@@ -684,6 +696,42 @@ export async function startAuction(
     },
     {
       pubkey: SYSVAR_CLOCK_PUBKEY,
+      isSigner: false,
+      isWritable: false,
+    },
+  ];
+  instructions.push(
+    new TransactionInstruction({
+      keys,
+      programId: auctionProgramId,
+      data: data,
+    }),
+  );
+}
+
+export async function setAuctionAuthority(
+  auction: PublicKey,
+  currentAuthority: PublicKey,
+  newAuthority: PublicKey,
+  instructions: TransactionInstruction[],
+) {
+  const auctionProgramId = programIds().auction;
+
+  const data = Buffer.from(serialize(AUCTION_SCHEMA, new SetAuthorityArgs()));
+
+  const keys = [
+    {
+      pubkey: auction,
+      isSigner: false,
+      isWritable: true,
+    },
+    {
+      pubkey: currentAuthority,
+      isSigner: true,
+      isWritable: false,
+    },
+    {
+      pubkey: newAuthority,
       isSigner: false,
       isWritable: false,
     },

--- a/js/packages/common/src/actions/vault.ts
+++ b/js/packages/common/src/actions/vault.ts
@@ -275,6 +275,42 @@ export const decodeSafetyDeposit = (buffer: Buffer) => {
   ) as SafetyDepositBox;
 };
 
+export async function setVaultAuthority(
+  vault: PublicKey,
+  currentAuthority: PublicKey,
+  newAuthority: PublicKey,
+  instructions: TransactionInstruction[],
+) {
+  const vaultProgramId = programIds().vault;
+
+  const data = Buffer.from([10]);
+
+  const keys = [
+    {
+      pubkey: vault,
+      isSigner: false,
+      isWritable: true,
+    },
+    {
+      pubkey: currentAuthority,
+      isSigner: true,
+      isWritable: false,
+    },
+    {
+      pubkey: newAuthority,
+      isSigner: false,
+      isWritable: false,
+    },
+  ];
+  instructions.push(
+    new TransactionInstruction({
+      keys,
+      programId: vaultProgramId,
+      data: data,
+    }),
+  );
+}
+
 export async function initVault(
   allowFurtherShareCreation: boolean,
   fractionalMint: PublicKey,

--- a/js/packages/web/src/actions/closeVault.ts
+++ b/js/packages/web/src/actions/closeVault.ts
@@ -24,7 +24,6 @@ export async function closeVault(
   redeemTreasury: PublicKey,
   priceMint: PublicKey,
   externalPriceAccount: PublicKey,
-  setAuthorityToAuctionManager: boolean,
 ): Promise<{
   instructions: TransactionInstruction[];
   signers: Keypair[];
@@ -45,13 +44,6 @@ export async function closeVault(
         vault.toBuffer(),
       ],
       PROGRAM_IDS.auction,
-    )
-  )[0];
-
-  const auctionManagerKey: PublicKey = (
-    await findProgramAddress(
-      [Buffer.from(METAPLEX_PREFIX), auctionKey.toBuffer()],
-      PROGRAM_IDS.metaplex,
     )
   )[0];
 
@@ -117,7 +109,7 @@ export async function closeVault(
     fractionMint,
     fractionTreasury,
     redeemTreasury,
-    setAuthorityToAuctionManager ? auctionManagerKey : wallet.publicKey,
+    wallet.publicKey,
     wallet.publicKey,
     transferAuthority.publicKey,
     externalPriceAccount,

--- a/js/packages/web/src/actions/createAuctionManager.ts
+++ b/js/packages/web/src/actions/createAuctionManager.ts
@@ -200,7 +200,6 @@ export async function createAuctionManager(
       redeemTreasury,
       priceMint,
       externalPriceAccount,
-      true,
     ),
     addTokens: { instructions: addTokenInstructions, signers: addTokenSigners },
     createReservationList: {

--- a/js/packages/web/src/actions/createAuctionManager.ts
+++ b/js/packages/web/src/actions/createAuctionManager.ts
@@ -48,6 +48,7 @@ import { createExternalPriceAccount } from './createExternalPriceAccount';
 import { validateParticipation } from '../models/metaplex/validateParticipation';
 import { createReservationListForTokens } from './createReservationListsForTokens';
 import { populatePrintingTokens } from './populatePrintingTokens';
+import { setVaultAndAuctionAuthorities } from './setVaultAndAuctionAuthorities';
 const { createTokenAccount } = actions;
 
 interface normalPattern {
@@ -72,6 +73,7 @@ interface byType {
   makeAuction: normalPattern;
   initAuctionManager: normalPattern;
   startAuction: normalPattern;
+  setVaultAndAuctionAuthorities: normalPattern;
   externalPriceAccount: normalPattern;
   validateParticipation?: normalPattern;
   buildAndPopulateOneTimeAuthorizationAccount?: normalPattern;
@@ -214,6 +216,12 @@ export async function createAuctionManager(
       instructions: auctionManagerInstructions,
       signers: auctionManagerSigners,
     },
+    setVaultAndAuctionAuthorities: await setVaultAndAuctionAuthorities(
+      wallet,
+      vault,
+      auction,
+      auctionManager,
+    ),
     startAuction: await setupStartAuction(wallet, vault),
     validateParticipation: participationSafetyDepositDraft
       ? await validateParticipationHelper(
@@ -264,6 +272,7 @@ export async function createAuctionManager(
     lookup.closeVault.signers,
     lookup.makeAuction.signers,
     lookup.initAuctionManager.signers,
+    lookup.setVaultAndAuctionAuthorities.signers,
     lookup.validateParticipation?.signers || [],
     ...lookup.validateBoxes.signers,
     lookup.startAuction.signers,
@@ -279,6 +288,7 @@ export async function createAuctionManager(
     lookup.closeVault.instructions,
     lookup.makeAuction.instructions,
     lookup.initAuctionManager.instructions,
+    lookup.setVaultAndAuctionAuthorities.instructions,
     lookup.validateParticipation?.instructions || [],
     ...lookup.validateBoxes.instructions,
     lookup.startAuction.instructions,

--- a/js/packages/web/src/actions/decommAuctionManagerAndReturnPrizes.ts
+++ b/js/packages/web/src/actions/decommAuctionManagerAndReturnPrizes.ts
@@ -1,5 +1,10 @@
 import { Keypair, Connection, TransactionInstruction } from '@solana/web3.js';
-import { sendTransactionsWithManualRetry, TokenAccount } from '@oyster/common';
+import {
+  sendTransactionsWithManualRetry,
+  setAuctionAuthority,
+  setVaultAuthority,
+  TokenAccount,
+} from '@oyster/common';
 
 import { AuctionView } from '../hooks';
 import { AuctionManagerStatus } from '../models/metaplex';
@@ -21,10 +26,28 @@ export async function decommAuctionManagerAndReturnPrizes(
   ) {
     let decomSigners: Keypair[] = [];
     let decomInstructions: TransactionInstruction[] = [];
+
+    if (auctionView.auction.info.authority.equals(wallet.publicKey)) {
+      await setAuctionAuthority(
+        auctionView.auction.pubkey,
+        wallet.publicKey,
+        auctionView.auctionManager.pubkey,
+        decomInstructions,
+      );
+    }
+    if (auctionView.vault.info.authority.equals(wallet.publicKey)) {
+      await setVaultAuthority(
+        auctionView.vault.pubkey,
+        wallet.publicKey,
+        auctionView.auctionManager.pubkey,
+        decomInstructions,
+      );
+    }
     await decommissionAuctionManager(
       auctionView.auctionManager.pubkey,
       auctionView.auction.pubkey,
       wallet.publicKey,
+      auctionView.vault.pubkey,
       decomInstructions,
     );
     signers.push(decomSigners);

--- a/js/packages/web/src/actions/makeAuction.ts
+++ b/js/packages/web/src/actions/makeAuction.ts
@@ -35,16 +35,9 @@ export async function makeAuction(
     )
   )[0];
 
-  const auctionManagerKey: PublicKey = (
-    await findProgramAddress(
-      [Buffer.from(METAPLEX_PREFIX), auctionKey.toBuffer()],
-      PROGRAM_IDS.metaplex,
-    )
-  )[0];
-
   const fullSettings = new CreateAuctionArgs({
     ...auctionSettings,
-    authority: auctionManagerKey,
+    authority: wallet.publicKey,
     resource: vault,
   });
 

--- a/js/packages/web/src/actions/setVaultAndAuctionAuthorities.ts
+++ b/js/packages/web/src/actions/setVaultAndAuctionAuthorities.ts
@@ -1,0 +1,48 @@
+import {
+  Keypair,
+  Connection,
+  PublicKey,
+  SystemProgram,
+  TransactionInstruction,
+} from '@solana/web3.js';
+import {
+  utils,
+  actions,
+  createMint,
+  findProgramAddress,
+  setAuctionAuthority,
+  setVaultAuthority,
+} from '@oyster/common';
+
+import { AccountLayout, MintLayout } from '@solana/spl-token';
+const { createTokenAccount, initVault, MAX_VAULT_SIZE, VAULT_PREFIX } = actions;
+
+// This command sets the authorities on the vault and auction to be the newly created auction manager.
+export async function setVaultAndAuctionAuthorities(
+  connection: Connection,
+  wallet: any,
+  vault: PublicKey,
+  auction: PublicKey,
+  auctionManager: PublicKey,
+): Promise<{
+  instructions: TransactionInstruction[];
+  signers: Keypair[];
+}> {
+  let signers: Keypair[] = [];
+  let instructions: TransactionInstruction[] = [];
+
+  await setAuctionAuthority(
+    auction,
+    wallet.publicKey,
+    auctionManager,
+    instructions,
+  );
+  await setVaultAuthority(
+    auction,
+    wallet.publicKey,
+    auctionManager,
+    instructions,
+  );
+
+  return { instructions, signers };
+}

--- a/js/packages/web/src/actions/setVaultAndAuctionAuthorities.ts
+++ b/js/packages/web/src/actions/setVaultAndAuctionAuthorities.ts
@@ -1,25 +1,8 @@
-import {
-  Keypair,
-  Connection,
-  PublicKey,
-  SystemProgram,
-  TransactionInstruction,
-} from '@solana/web3.js';
-import {
-  utils,
-  actions,
-  createMint,
-  findProgramAddress,
-  setAuctionAuthority,
-  setVaultAuthority,
-} from '@oyster/common';
-
-import { AccountLayout, MintLayout } from '@solana/spl-token';
-const { createTokenAccount, initVault, MAX_VAULT_SIZE, VAULT_PREFIX } = actions;
+import { Keypair, PublicKey, TransactionInstruction } from '@solana/web3.js';
+import { setAuctionAuthority, setVaultAuthority } from '@oyster/common';
 
 // This command sets the authorities on the vault and auction to be the newly created auction manager.
 export async function setVaultAndAuctionAuthorities(
-  connection: Connection,
   wallet: any,
   vault: PublicKey,
   auction: PublicKey,
@@ -38,7 +21,7 @@ export async function setVaultAndAuctionAuthorities(
     instructions,
   );
   await setVaultAuthority(
-    auction,
+    vault,
     wallet.publicKey,
     auctionManager,
     instructions,

--- a/js/packages/web/src/actions/unwindVault.ts
+++ b/js/packages/web/src/actions/unwindVault.ts
@@ -53,7 +53,6 @@ export async function unwindVault(
           vault.info.redeemTreasury,
           decoded.priceMint,
           vault.info.pricingLookupAddress,
-          false,
         );
 
       signers.push(cvSigners);

--- a/js/packages/web/src/components/Notifications/index.tsx
+++ b/js/packages/web/src/components/Notifications/index.tsx
@@ -11,10 +11,7 @@ import {
   useWallet,
   VaultState,
 } from '@oyster/common';
-import {
-  Connection,
-  PublicKey,
-} from '@solana/web3.js';
+import { Connection, PublicKey } from '@solana/web3.js';
 import { Badge, Popover, List } from 'antd';
 import React, { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
@@ -26,10 +23,7 @@ import { settle } from '../../actions/settle';
 
 import { QUOTE_MINT } from '../../constants';
 import { useMeta } from '../../contexts';
-import {
-  AuctionViewState,
-  useAuctions,
-} from '../../hooks';
+import { AuctionViewState, useAuctions } from '../../hooks';
 import './index.less';
 import { WalletAdapter } from '@solana/wallet-base';
 interface NotificationCard {
@@ -180,7 +174,7 @@ export function useSettlementAuctions({
   notifications: NotificationCard[];
 }) {
   const { accountByMint } = useUserAccounts();
-  const walletPubkey = wallet?.publicKey?.toBase58() || '';
+  const walletPubkey = wallet?.publicKey;
   const { bidderPotsByAuctionAndBidder } = useMeta();
   const auctionsNeedingSettling = useAuctions(AuctionViewState.Ended);
 
@@ -191,7 +185,8 @@ export function useSettlementAuctions({
       const nextBatch = auctionsNeedingSettling
         .filter(
           a =>
-            a.auctionManager.info.authority.toBase58() === walletPubkey &&
+            walletPubkey &&
+            a.auctionManager.info.authority.equals(walletPubkey) &&
             a.auction.info.ended(),
         )
         .sort(
@@ -270,7 +265,6 @@ export function useSettlementAuctions({
               myPayingAccount?.pubkey,
               accountByMint,
             );
-            const PROGRAM_IDS = programIds();
             if (wallet?.publicKey) {
               const ata = await getPersonalEscrowAta(wallet);
               if (ata) await closePersonalEscrow(connection, wallet, ata);

--- a/js/packages/web/src/models/metaplex/decommissionAuctionManager.ts
+++ b/js/packages/web/src/models/metaplex/decommissionAuctionManager.ts
@@ -12,6 +12,7 @@ export async function decommissionAuctionManager(
   auctionManager: PublicKey,
   auction: PublicKey,
   authority: PublicKey,
+  vault: PublicKey,
   instructions: TransactionInstruction[],
 ) {
   const PROGRAM_IDS = programIds();
@@ -41,6 +42,11 @@ export async function decommissionAuctionManager(
       isWritable: false,
     },
 
+    {
+      pubkey: vault,
+      isSigner: false,
+      isWritable: false,
+    },
     {
       pubkey: store,
       isSigner: false,

--- a/rust/auction/program/src/processor/set_authority.rs
+++ b/rust/auction/program/src/processor/set_authority.rs
@@ -35,6 +35,12 @@ pub fn set_authority(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramRe
         return Err(AuctionError::InvalidAuthority.into());
     }
 
+    // Make sure new authority actually exists in some form.
+    if new_authority.data_is_empty() || new_authority.lamports() == 0 {
+        msg!("Disallowing new authority because it does not exist.");
+        return Err(AuctionError::InvalidAuthority.into());
+    }
+
     auction.authority = *new_authority.key;
     auction.serialize(&mut *auction_act.data.borrow_mut())?;
     Ok(())

--- a/rust/metaplex/program/src/instruction.rs
+++ b/rust/metaplex/program/src/instruction.rs
@@ -357,9 +357,10 @@ pub enum MetaplexInstruction {
     /// 0. `[writable]` Auction Manager
     /// 1. `[writable]` Auction
     /// 2. `[Signer]` Authority of the Auction Manager
-    /// 3. `[]` Store
-    /// 4. `[]` Auction program
-    /// 5. `[]` Clock sysvar
+    /// 3. `[]` Vault
+    /// 4. `[]` Store
+    /// 5. `[]` Auction program
+    /// 6. `[]` Clock sysvar
     DecommissionAuctionManager,
 }
 

--- a/rust/metaplex/program/src/processor/decommission_auction_manager.rs
+++ b/rust/metaplex/program/src/processor/decommission_auction_manager.rs
@@ -13,6 +13,8 @@ use {
         entrypoint::ProgramResult,
         pubkey::Pubkey,
     },
+    spl_auction::processor::AuctionData,
+    spl_token_vault::state::Vault,
 };
 
 pub fn process_decommission_auction_manager<'a>(
@@ -23,6 +25,7 @@ pub fn process_decommission_auction_manager<'a>(
 
     let auction_manager_info = next_account_info(account_info_iter)?;
     let auction_info = next_account_info(account_info_iter)?;
+    let vault_info = next_account_info(account_info_iter)?;
     let authority_info = next_account_info(account_info_iter)?;
     let store_info = next_account_info(account_info_iter)?;
     let auction_program_info = next_account_info(account_info_iter)?;
@@ -31,10 +34,20 @@ pub fn process_decommission_auction_manager<'a>(
     assert_owned_by(auction_manager_info, program_id)?;
     assert_owned_by(store_info, program_id)?;
     assert_signer(authority_info)?;
-
     let mut auction_manager = AuctionManager::from_account_info(auction_manager_info)?;
+    let vault = Vault::from_account_info(vault_info)?;
+    let auction = AuctionData::from_account_info(auction_manager_info)?;
+
     let store = Store::from_account_info(store_info)?;
     assert_authority_correct(&auction_manager, authority_info)?;
+
+    if auction.authority != *auction_manager_info.key {
+        return Err(MetaplexError::AuctionAuthorityMismatch.into());
+    }
+
+    if vault.authority != *auction_manager_info.key {
+        return Err(MetaplexError::VaultAuthorityMismatch.into());
+    }
 
     if auction_manager.state.status != AuctionManagerStatus::Initialized {
         return Err(MetaplexError::InvalidStatus.into());

--- a/rust/metaplex/program/src/processor/decommission_auction_manager.rs
+++ b/rust/metaplex/program/src/processor/decommission_auction_manager.rs
@@ -25,18 +25,18 @@ pub fn process_decommission_auction_manager<'a>(
 
     let auction_manager_info = next_account_info(account_info_iter)?;
     let auction_info = next_account_info(account_info_iter)?;
-    let vault_info = next_account_info(account_info_iter)?;
     let authority_info = next_account_info(account_info_iter)?;
+    let vault_info = next_account_info(account_info_iter)?;
     let store_info = next_account_info(account_info_iter)?;
     let auction_program_info = next_account_info(account_info_iter)?;
     let clock_info = next_account_info(account_info_iter)?;
-
     assert_owned_by(auction_manager_info, program_id)?;
     assert_owned_by(store_info, program_id)?;
     assert_signer(authority_info)?;
+
     let mut auction_manager = AuctionManager::from_account_info(auction_manager_info)?;
     let vault = Vault::from_account_info(vault_info)?;
-    let auction = AuctionData::from_account_info(auction_manager_info)?;
+    let auction = AuctionData::from_account_info(auction_info)?;
 
     let store = Store::from_account_info(store_info)?;
     assert_authority_correct(&auction_manager, authority_info)?;

--- a/rust/metaplex/program/src/processor/init_auction_manager.rs
+++ b/rust/metaplex/program/src/processor/init_auction_manager.rs
@@ -53,14 +53,6 @@ pub fn process_init_auction_manager(
         return Err(MetaplexError::AuctionMustBeCreated.into());
     }
 
-    if vault.authority != *auction_manager_info.key {
-        return Err(MetaplexError::VaultAuthorityMismatch.into());
-    }
-
-    if auction.authority != *auction_manager_info.key {
-        return Err(MetaplexError::AuctionAuthorityMismatch.into());
-    }
-
     let bump_seed = assert_derivation(
         program_id,
         auction_manager_info,

--- a/rust/metaplex/program/src/processor/start_auction.rs
+++ b/rust/metaplex/program/src/processor/start_auction.rs
@@ -11,7 +11,10 @@ use {
         program::invoke_signed,
         pubkey::Pubkey,
     },
-    spl_auction::instruction::{start_auction_instruction, StartAuctionArgs},
+    spl_auction::{
+        instruction::{start_auction_instruction, StartAuctionArgs},
+        processor::AuctionData,
+    },
 };
 
 pub fn issue_start_auction<'a>(
@@ -45,7 +48,12 @@ pub fn process_start_auction(program_id: &Pubkey, accounts: &[AccountInfo]) -> P
     let clock_info = next_account_info(account_info_iter)?;
 
     let mut auction_manager = AuctionManager::from_account_info(auction_manager_info)?;
+    let auction = AuctionData::from_account_info(auction_info)?;
     let store = Store::from_account_info(store_info)?;
+
+    if auction.authority != *auction_manager_info.key {
+        return Err(MetaplexError::AuctionAuthorityMismatch.into());
+    }
 
     assert_authority_correct(&auction_manager, authority_info)?;
     assert_owned_by(auction_info, &store.auction_program)?;

--- a/rust/metaplex/program/src/processor/validate_participation.rs
+++ b/rust/metaplex/program/src/processor/validate_participation.rs
@@ -52,6 +52,10 @@ pub fn process_validate_participation(
     let open_edition_metadata = Metadata::from_account_info(open_edition_metadata_info)?;
     let master_edition = MasterEdition::from_account_info(open_master_edition_info)?;
 
+    if vault.authority != *auction_manager_info.key {
+        return Err(MetaplexError::VaultAuthorityMismatch.into());
+    }
+
     // top level authority and ownership check
     assert_authority_correct(&auction_manager, authority_info)?;
     assert_owned_by(auction_manager_info, program_id)?;

--- a/rust/metaplex/program/src/processor/validate_safety_deposit_box.rs
+++ b/rust/metaplex/program/src/processor/validate_safety_deposit_box.rs
@@ -104,9 +104,13 @@ pub fn process_validate_safety_deposit_box(
     let metadata = Metadata::from_account_info(metadata_info)?;
     let store = Store::from_account_info(auction_manager_store_info)?;
     // Is it a real vault?
-    let _vault = Vault::from_account_info(vault_info)?;
+    let vault = Vault::from_account_info(vault_info)?;
     // Is it a real mint?
     let _mint: Mint = assert_initialized(mint_info)?;
+
+    if vault.authority != *auction_manager_info.key {
+        return Err(MetaplexError::VaultAuthorityMismatch.into());
+    }
 
     assert_owned_by(auction_manager_info, program_id)?;
     assert_owned_by(metadata_info, &store.token_metadata_program)?;

--- a/rust/token-vault/program/src/instruction.rs
+++ b/rust/token-vault/program/src/instruction.rs
@@ -140,6 +140,13 @@ pub enum VaultInstruction {
     /// Useful for testing purposes, and the CLI makes use of it as well so that you can verify logic.
     ///   0. `[writable]` External price account
     UpdateExternalPriceAccount(ExternalPriceAccount),
+
+    /// Sets the authority of the vault to a new authority.
+    ///
+    ///   0. `[writable]` Vault
+    ///   1. `[signer]` Vault authority
+    ///   2. `[]` New authority
+    SetAuthority,
 }
 
 /// Creates an InitVault instruction
@@ -430,5 +437,22 @@ pub fn create_add_shares_instruction(
         data: VaultInstruction::AddSharesToTreasury(NumberOfShareArgs { number_of_shares })
             .try_to_vec()
             .unwrap(),
+    }
+}
+
+pub fn create_set_authority_instruction(
+    program_id: Pubkey,
+    vault: Pubkey,
+    current_authority: Pubkey,
+    new_authority: Pubkey,
+) -> Instruction {
+    Instruction {
+        program_id,
+        accounts: vec![
+            AccountMeta::new(vault, false),
+            AccountMeta::new_readonly(current_authority, true),
+            AccountMeta::new_readonly(new_authority, false),
+        ],
+        data: VaultInstruction::SetAuthority.try_to_vec().unwrap(),
     }
 }

--- a/rust/token-vault/program/src/processor.rs
+++ b/rust/token-vault/program/src/processor.rs
@@ -84,6 +84,10 @@ pub fn process_instruction(
                 args.allowed_to_combine,
             )
         }
+        VaultInstruction::SetAuthority => {
+            msg!("Instruction: Set Authority");
+            process_set_authority(program_id, accounts)
+        }
     }
 }
 
@@ -108,6 +112,35 @@ pub fn process_update_external_price_account(
     external_price_account.allowed_to_combine = allowed_to_combine;
 
     external_price_account.serialize(&mut *account.data.borrow_mut())?;
+
+    Ok(())
+}
+
+pub fn process_set_authority(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let vault_info = next_account_info(account_info_iter)?;
+    let current_authority_info = next_account_info(account_info_iter)?;
+    let new_authority_info = next_account_info(account_info_iter)?;
+
+    let mut vault = Vault::from_account_info(vault_info)?;
+    assert_owned_by(vault_info, program_id)?;
+
+    if vault.authority != *current_authority_info.key {
+        return Err(VaultError::InvalidAuthority.into());
+    }
+
+    if !current_authority_info.is_signer {
+        return Err(VaultError::InvalidAuthority.into());
+    }
+
+    // Make sure new authority actually exists in some form.
+    if new_authority_info.data_is_empty() || new_authority_info.lamports() == 0 {
+        msg!("Disallowing new authority because it does not exist.");
+        return Err(VaultError::InvalidAuthority.into());
+    }
+
+    vault.authority = *new_authority_info.key;
+    vault.serialize(&mut *vault_info.data.borrow_mut())?;
 
     Ok(())
 }


### PR DESCRIPTION
This PR fixes a potential issue that happens where we create auctions and vaults and grant them to auction managers that may never get created, or may later get created by somebody else. Very iffy stuff. This instead reverses the order - auction managers must exist before they can be set as authorities, and auction managers will allow vaults and auctions to be set on them that do not have them as authorities during initialization. It is only during the validation, start, and decomm steps that they check for authorities. The front end has been adjusted to account for this.

This also prevents Unwinding Case 3 mentioned in https://github.com/metaplex-foundation/metaplex/issues/85