### PR TITLE
Wider Browser Version Support for NFT Upload

### DIFF
--- a/js/packages/web/src/utils/utils.ts
+++ b/js/packages/web/src/utils/utils.ts
@@ -3,7 +3,7 @@ export const cleanName = (name?: string): string | undefined => {
     return undefined;
   }
 
-  return name.replaceAll(' ', '-');
+  return name.replace(/\s+/g, '-');
 };
 
 export const getLast = <T>(arr: T[]) => {


### PR DESCRIPTION
### Issue

replaceAll is only available on Chrome 85+. The workstation is currently on Chrome 83 and the replaceAll method is undefined on string.

### Solution
Switch to replace with g flag which is the same but has greater browser support.