### PR TITLE
Fix bug: Items doesn't show up under created tab

### DIFF
--- a/js/packages/web/src/hooks/useCreatorArts.ts
+++ b/js/packages/web/src/hooks/useCreatorArts.ts
@@ -4,9 +4,9 @@ import { PublicKey } from '@solana/web3.js';
 export const useCreatorArts = (id?: PublicKey | string) => {
   const { metadata } = useMeta();
   const filtered = metadata.filter(
-    m =>
-      (m.info.data.creators?.findIndex(c => c.address.toBase58() === id) ||
-        -1) >= 0,
+    m => 
+      m.info.data.creators !== null 
+      && m.info.data.creators.findIndex(c => c.address.toBase58() === id) >= 0
   );
 
   return filtered;

--- a/js/packages/web/src/views/artworks/index.tsx
+++ b/js/packages/web/src/views/artworks/index.tsx
@@ -3,7 +3,7 @@ import { ArtCard } from '../../components/ArtCard';
 import { Layout, Row, Col, Tabs } from 'antd';
 import Masonry from 'react-masonry-css';
 import { Link } from 'react-router-dom';
-import { useUserArts } from '../../hooks';
+import { useCreatorArts, useUserArts } from '../../hooks';
 import { useMeta } from '../../contexts';
 import { CardLoader } from '../../components/MyLoader';
 import { useWallet } from '@oyster/common';
@@ -19,8 +19,9 @@ export enum ArtworkViewState {
 }
 
 export const ArtworksView = () => {
-  const { connected } = useWallet();
+  const { connected, wallet } = useWallet();
   const ownedMetadata = useUserArts();
+  const createdMetadata = useCreatorArts(wallet?.publicKey?.toBase58() || '');
   const { metadata, isLoading } = useMeta();
   const [activeKey, setActiveKey] = useState(ArtworkViewState.Metaplex);
   const breakpointColumnsObj = {
@@ -31,9 +32,11 @@ export const ArtworksView = () => {
   };
 
   const items =
-    activeKey === ArtworkViewState.Metaplex
-      ? metadata
-      : ownedMetadata.map(m => m.metadata);
+    (activeKey === ArtworkViewState.Owned
+      ? ownedMetadata.map(m => m.metadata)
+      : (activeKey === ArtworkViewState.Created 
+        ? createdMetadata 
+        : metadata));
 
   useEffect(() => {
     if(connected) {


### PR DESCRIPTION
Fix #52 
This commit also fix:
- Some items doesn't show up on an artist page when the artist is the only creator.
- Some item you created doesn't show up under created tab when you're doesn't have the item.

The problem.
```ts
(m.info.data.creators?.findIndex(c => c.address.toBase58() === id) || -1) >= 0
```
The code above, will return `-1` when the `findIndex` function returning index `0`.
So, Instead of using `optional chaining`, I check it manually.

Thanks.