### PR TITLE
[FIX] Next.js deploy failed on Vercel & Cloudflare

### DIFF
--- a/js/deploy-web.bat
+++ b/js/deploy-web.bat
@@ -9,5 +9,5 @@ ECHO "Prestarting 'web'..."
 yarn prestart
 ECHO "Building 'web'..."
 # TODO: fix linting errors!
-SET CI=false && yarn build
+SET CI=false && yarn build && yarn export
 ECHO "#done"

--- a/js/deploy-web.sh
+++ b/js/deploy-web.sh
@@ -9,5 +9,5 @@ echo "Prestarting 'web'..."
 yarn prestart
 echo "Building 'web'..."
 # TODO: fix linting errors!
-CI=false && yarn build
+CI=false && yarn build && yarn export
 echo "#done"


### PR DESCRIPTION
After having a hard time to deploy these big changes (from CRA to Next.js) to Cloudflare & Vercel. I managed to get this work by adding `yarn export` after `yarn build` execution inside `deploy-web.sh`

These are how my hosting settings look like.

1. Set root directory to `js`
2. Build command `./deploy-web.sh`
3. Set output directory to `build/web`

So the instruction in `deploy.md` could be misleading cc: @exromany 
We need to add another type of deployment instruction, since not all developer want to deploy Metaplex on Github pages. cc: @bartosz-lipinski 