### PR TITLE
Don't display store_owner_address on non-localhost sites.

### DIFF
--- a/js/packages/common/src/utils/ids.ts
+++ b/js/packages/common/src/utils/ids.ts
@@ -1,5 +1,5 @@
 import { PublicKey } from '@solana/web3.js';
-import { findProgramAddress } from '../utils';
+import { findProgramAddress, is_localhost } from '../utils';
 
 export const WRAPPED_SOL_MINT = new PublicKey(
   'So11111111111111111111111111111111111111112',
@@ -70,7 +70,9 @@ export const setStoreID = (storeId: any) => {
 };
 
 const getStoreID = async () => {
-  console.log(`STORE_OWNER_ADDRESS: ${STORE_OWNER_ADDRESS?.toBase58()}`);
+  if (is_localhost()) {
+    console.log(`STORE_OWNER_ADDRESS: ${STORE_OWNER_ADDRESS?.toBase58()}`);
+  }
   if (!STORE_OWNER_ADDRESS) {
     return undefined;
   }
@@ -84,7 +86,9 @@ const getStoreID = async () => {
     METAPLEX_ID,
   );
   const CUSTOM = programs[0];
-  console.log(`CUSTOM STORE: ${CUSTOM.toBase58()}`);
+  if (is_localhost()) {
+    console.log(`CUSTOM STORE: ${CUSTOM.toBase58()}`);
+  }
 
   return CUSTOM;
 };

--- a/js/packages/common/src/utils/utils.ts
+++ b/js/packages/common/src/utils/utils.ts
@@ -298,3 +298,10 @@ export function convert(
 export function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
+
+export function is_localhost(): boolean {
+  return (
+    window.location.hostname === 'localhost' ||
+    window.location.hostname === '127.0.0.1'
+  );
+}


### PR DESCRIPTION
This is to prevent people who are using their personal wallet address as the store owner address from accidentally leaking their wallet on their production sites.