### PR TITLE
Making Metaplex packages publishable to crates.io

### DIFF
--- a/rust/auction/cli/Cargo.toml
+++ b/rust/auction/cli/Cargo.toml
@@ -18,5 +18,5 @@ solana-cli-config = "1.6"
 solana-client = "1.6.10"
 solana-program = "1.6.10"
 solana-sdk = "1.6.10"
-spl-auction = { path = "../program", features = [ "no-entrypoint" ] }
+spl-auction = { path = "../program", features = [ "no-entrypoint" ], version = "0.0.1" }
 spl-token = { version="3.1.1", features = [ "no-entrypoint" ] }

--- a/rust/metaplex/program/Cargo.toml
+++ b/rust/metaplex/program/Cargo.toml
@@ -13,14 +13,14 @@ no-entrypoint = []
 test-bpf = []
 
 [dependencies]
-spl-auction = { path = "../../auction/program", features = [ "no-entrypoint" ] }
+spl-auction = { path = "../../auction/program", features = [ "no-entrypoint" ], version = "0.0.1" }
 num-derive = "0.3"
 num-traits = "0.2"
 arrayref = "0.3.6"
 solana-program = "1.6.10"
 spl-token = { version="3.1.1", features = [ "no-entrypoint" ] }
-spl-token-vault = { path = "../../token-vault/program", features = [ "no-entrypoint" ] }
-spl-token-metadata = { path = "../../token-metadata/program", features = [ "no-entrypoint" ] }
+spl-token-vault = { path = "../../token-vault/program", features = [ "no-entrypoint" ], version = "0.0.1" }
+spl-token-metadata = { path = "../../token-metadata/program", features = [ "no-entrypoint" ], version = "0.0.1" }
 thiserror = "1.0"
 borsh = "0.9.1"
 

--- a/rust/token-metadata/program/Cargo.toml
+++ b/rust/token-metadata/program/Cargo.toml
@@ -17,7 +17,7 @@ num-derive = "0.3"
 arrayref = "0.3.6"
 num-traits = "0.2"
 solana-program = "1.6.10"
-spl-token-vault = { path = "../../token-vault/program", features = [ "no-entrypoint" ] }
+spl-token-vault = { path = "../../token-vault/program", features = [ "no-entrypoint" ], version = "0.0.1" }
 spl-token = { version="3.1.1", features = [ "no-entrypoint" ] }
 thiserror = "1.0"
 borsh = "0.9.1"


### PR DESCRIPTION
The goal of this pull request is to make it possible for anyone to interface with the Metaplex programs (`metaplex`, `token-metadata`, `token-vault`, `auction`) by import packages from crates.io into Rust programs.