### PR TITLE
Fix NFT Mint via Custom URL

### DIFF
--- a/js/packages/web/src/views/artCreate/index.tsx
+++ b/js/packages/web/src/views/artCreate/index.tsx
@@ -295,7 +295,7 @@ const UploadStep = (props: {
 
   const [customURL, setCustomURL] = useState<string>('');
   const [customURLErr, setCustomURLErr] = useState<string>('');
-  const disableContinue = !coverFile || !!customURLErr;
+  const disableContinue = !!coverFile || !!customURLErr;
 
   useEffect(() => {
     props.setAttributes({


### PR DESCRIPTION
Continue Mint was disabled when inserting absolute URL.

Fixes: #201 