### PR TITLE
Replace pubkey.toBase58 with pubKey.equals for many pubkey comparisons

### DIFF
--- a/js/packages/common/src/actions/account.ts
+++ b/js/packages/common/src/actions/account.ts
@@ -289,18 +289,17 @@ export function findOrCreateAccountByMint(
   signers: Keypair[],
   excluded?: Set<string>,
 ): PublicKey {
-  const accountToFind = mint.toBase58();
   const account = cache
     .byParser(TokenAccountParser)
     .map(id => cache.get(id))
     .find(
       acc =>
         acc !== undefined &&
-        acc.info.mint.toBase58() === accountToFind &&
-        acc.info.owner.toBase58() === owner.toBase58() &&
+        acc.info.mint.equals(mint) &&
+        acc.info.owner.equals(owner) &&
         (excluded === undefined || !excluded.has(acc.pubkey.toBase58())),
     );
-  const isWrappedSol = accountToFind === WRAPPED_SOL_MINT.toBase58();
+  const isWrappedSol = mint.equals(WRAPPED_SOL_MINT);
 
   let toAccount: PublicKey;
   if (account && !isWrappedSol) {

--- a/js/packages/common/src/actions/auction.ts
+++ b/js/packages/common/src/actions/auction.ts
@@ -65,9 +65,7 @@ export class BidState {
   public getWinnerIndex(bidder: PublicKey): number | null {
     if (!this.bids) return null;
 
-    const index = this.bids.findIndex(
-      b => b.key.toBase58() === bidder.toBase58(),
-    );
+    const index = this.bids.findIndex(b => b.key.equals(bidder));
     // auction stores data in reverse order
     if (index !== -1) {
       const zeroBased = this.bids.length - index - 1;

--- a/js/packages/common/src/contexts/accounts.tsx
+++ b/js/packages/common/src/contexts/accounts.tsx
@@ -394,7 +394,11 @@ export function AccountsProvider({ children = null as any }) {
       .byParser(TokenAccountParser)
       .map(id => cache.get(id))
       .filter(
-        a => a && a.info.owner.toBase58() === wallet?.publicKey?.toBase58(),
+        a =>
+          a &&
+          wallet !== undefined &&
+          wallet.publicKey !== null &&
+          a.info.owner.equals(wallet.publicKey),
       )
       .map(a => a as TokenAccount);
   }, [wallet]);

--- a/js/packages/common/src/hooks/useAccountByMint.ts
+++ b/js/packages/common/src/hooks/useAccountByMint.ts
@@ -2,11 +2,15 @@ import { PublicKey } from '@solana/web3.js';
 import { useUserAccounts } from '../hooks/useUserAccounts';
 
 export const useAccountByMint = (mint?: string | PublicKey) => {
-  const { userAccounts } = useUserAccounts();
-  const mintAddress = typeof mint === 'string' ? mint : mint?.toBase58();
+  if (mint === undefined) {
+    return undefined;
+  }
 
-  const index = userAccounts.findIndex(
-    acc => acc.info.mint.toBase58() === mintAddress,
+  const { userAccounts } = useUserAccounts();
+  const mintAddress = typeof mint === 'string' ? new PublicKey(mint) : mint;
+
+  const index = userAccounts.findIndex(acc =>
+    acc.info.mint.equals(mintAddress),
   );
 
   if (index !== -1) {

--- a/js/packages/web/src/actions/settle.ts
+++ b/js/packages/web/src/actions/settle.ts
@@ -96,9 +96,7 @@ async function emptyPaymentAccountForAllTokens(
       const creators = item.metadata.info.data.creators;
       const edgeCaseWhereCreatorIsAuctioneer = !!creators
         ?.map(c => c.address)
-        .find(
-          c => c.toBase58() === auctionView.auctionManager.authority.toBase58(),
-        );
+        .find(c => c.equals(auctionView.auctionManager.authority));
 
       const addresses = [
         ...(creators ? creators.map(c => c.address) : []),

--- a/js/packages/web/src/components/ArtContent/index.tsx
+++ b/js/packages/web/src/components/ArtContent/index.tsx
@@ -173,9 +173,9 @@ export const ArtContent = ({
   animationURL?: string;
   files?: (MetadataFile | string)[];
 }) => {
-  const id = pubkeyToString(pubkey);
+  const key = typeof pubkey === 'string' ? new PublicKey(pubkey) : pubkey;
 
-  const { ref, data } = useExtendedArt(id);
+  const { ref, data } = useExtendedArt(key);
 
   if (pubkey && data) {
     uri = data.image;

--- a/js/packages/web/src/components/AuctionCard/index.tsx
+++ b/js/packages/web/src/components/AuctionCard/index.tsx
@@ -239,8 +239,9 @@ export const AuctionCard = ({
   const gapBidInvalid = useGapTickCheck(value, gapTick, gapTime, auctionView);
 
   const isAuctionManagerAuthorityNotWalletOwner =
-    auctionView.auctionManager.authority.toBase58() !=
-    wallet?.publicKey?.toBase58();
+    wallet === undefined ||
+    wallet.publicKey === null ||
+    !auctionView.auctionManager.authority.equals(wallet.publicKey);
 
   const isAuctionNotStarted =
     auctionView.auction.info.state === AuctionState.Created;

--- a/js/packages/web/src/components/Notifications/index.tsx
+++ b/js/packages/web/src/components/Notifications/index.tsx
@@ -240,12 +240,12 @@ export function useSettlementAuctions({
     const myPayingAccount = accountByMint.get(
       auctionView.auction.info.tokenMint.toBase58(),
     );
-    const auctionKey = auctionView.auction.pubkey.toBase58();
+    const auctionKey = auctionView.auction.pubkey;
     const bidsToClaim = Object.values(bidderPotsByAuctionAndBidder).filter(
       b =>
         winners[b.info.bidderAct.toBase58()] &&
         !b.info.emptied &&
-        b.info.auctionAct.toBase58() === auctionKey,
+        b.info.auctionAct.equals(auctionKey),
     );
     if (bidsToClaim.length || validDiscoveredEndedAuctions[auctionViewKey] > 0)
       notifications.push({
@@ -302,7 +302,7 @@ export function Notifications() {
 
   const notifications: NotificationCard[] = [];
 
-  const walletPubkey = wallet?.publicKey?.toBase58() || '';
+  const walletPubkey = wallet?.publicKey ?? undefined;
 
   useCollapseWrappedSol({ connection, wallet, notifications });
 
@@ -312,7 +312,8 @@ export function Notifications() {
     () =>
       Object.values(vaults).filter(
         v =>
-          v.info.authority.toBase58() === walletPubkey &&
+          walletPubkey !== undefined &&
+          v.info.authority.equals(walletPubkey) &&
           v.info.state !== VaultState.Deactivated &&
           v.info.tokenTypeCount > 0,
       ),
@@ -347,7 +348,11 @@ export function Notifications() {
   });
 
   possiblyBrokenAuctionManagerSetups
-    .filter(v => v.auctionManager.authority.toBase58() === walletPubkey)
+    .filter(
+      v =>
+        walletPubkey !== undefined &&
+        v.auctionManager.authority.equals(walletPubkey),
+    )
     .forEach(v => {
       notifications.push({
         id: v.auctionManager.pubkey.toBase58(),
@@ -384,7 +389,10 @@ export function Notifications() {
             ?.activated ||
             store?.info.public) &&
           m.info.data.creators.find(
-            c => c.address.toBase58() === walletPubkey && !c.verified,
+            c =>
+              walletPubkey !== undefined &&
+              c.address.equals(walletPubkey) &&
+              !c.verified,
           )
         );
       }),
@@ -416,7 +424,11 @@ export function Notifications() {
   });
 
   upcomingAuctions
-    .filter(v => v.auctionManager.authority.toBase58() === walletPubkey)
+    .filter(
+      v =>
+        walletPubkey !== undefined &&
+        v.auctionManager.authority.equals(walletPubkey),
+    )
     .forEach(v => {
       notifications.push({
         id: v.auctionManager.pubkey.toBase58(),

--- a/js/packages/web/src/hooks/useArt.ts
+++ b/js/packages/web/src/hooks/useArt.ts
@@ -13,7 +13,6 @@ import {
 import { WhitelistedCreator } from '../models/metaplex';
 import { Cache } from 'three';
 import { useInView } from 'react-intersection-observer';
-import { pubkeyToString } from '../utils/pubkeyToString';
 
 const metadataToArt = (
   info: Metadata | undefined,
@@ -137,12 +136,15 @@ export const useArt = (id?: PublicKey | string) => {
   const { metadata, editions, masterEditions, whitelistedCreatorsByCreator } =
     useMeta();
 
-  const key = pubkeyToString(id);
+  const account = useMemo(() => {
+    if (id === undefined) {
+      return undefined;
+    }
 
-  const account = useMemo(
-    () => metadata.find(a => a.pubkey.toBase58() === key),
-    [key, metadata],
-  );
+    const key = typeof id === 'string' ? new PublicKey(id) : id;
+
+    return metadata.find(a => a.pubkey.equals(key));
+  }, [id, metadata]);
 
   const art = useMemo(
     () =>
@@ -164,12 +166,15 @@ export const useExtendedArt = (id?: PublicKey | string) => {
   const [data, setData] = useState<IMetadataExtension>();
   const { ref, inView } = useInView();
 
-  const key = pubkeyToString(id);
+  const account = useMemo(() => {
+    if (id === undefined) {
+      return undefined;
+    }
 
-  const account = useMemo(
-    () => metadata.find(a => a.pubkey.toBase58() === key),
-    [key, metadata],
-  );
+    const key = typeof id === 'string' ? new PublicKey(id) : id;
+
+    return metadata.find(a => a.pubkey.equals(key));
+  }, [id, metadata]);
 
   useEffect(() => {
     if (inView && id && !data) {

--- a/js/packages/web/src/hooks/useCreator.ts
+++ b/js/packages/web/src/hooks/useCreator.ts
@@ -3,10 +3,15 @@ import { useMeta } from '../contexts';
 import { pubkeyToString } from '../utils/pubkeyToString';
 
 export const useCreator = (id?: PublicKey | string) => {
+  if (id === undefined) {
+    return undefined;
+  }
+
+  const key = typeof id === 'string' ? new PublicKey(id) : id;
+
   const { whitelistedCreatorsByCreator } = useMeta();
-  const key = pubkeyToString(id);
   const creator = Object.values(whitelistedCreatorsByCreator).find(
-    creator => creator.info.address.toBase58() === key,
+    creator => creator.info.address.equals(key),
   );
   return creator;
 };

--- a/js/packages/web/src/hooks/useCreatorArts.ts
+++ b/js/packages/web/src/hooks/useCreatorArts.ts
@@ -2,9 +2,14 @@ import { useMeta } from '../contexts';
 import { PublicKey } from '@solana/web3.js';
 
 export const useCreatorArts = (id?: PublicKey | string) => {
+  if (id === undefined) {
+    return [];
+  }
+  const key = typeof id === 'string' ? new PublicKey(id) : id;
+
   const { metadata } = useMeta();
   const filtered = metadata.filter(m =>
-    m.info.data.creators?.some(c => c.address.toBase58() === id),
+    m.info.data.creators?.some(c => c.address.equals(key)),
   );
 
   return filtered;

--- a/js/packages/web/src/hooks/useUserBalance.ts
+++ b/js/packages/web/src/hooks/useUserBalance.ts
@@ -9,7 +9,9 @@ export function useUserBalance(
 ) {
   const mint = useMemo(
     () =>
-      typeof mintAddress === 'string' ? mintAddress : mintAddress?.toBase58(),
+      typeof mintAddress === 'string'
+        ? new PublicKey(mintAddress)
+        : mintAddress,
     [mintAddress],
   );
   const { userAccounts } = useUserAccounts();
@@ -22,7 +24,8 @@ export function useUserBalance(
     return userAccounts
       .filter(
         acc =>
-          mint === acc.info.mint.toBase58() &&
+          mint !== undefined &&
+          mint.equals(acc.info.mint) &&
           (!account || account.equals(acc.pubkey)),
       )
       .sort((a, b) => b.info.amount.sub(a.info.amount).toNumber());

--- a/js/packages/web/src/views/artCreate/index.tsx
+++ b/js/packages/web/src/views/artCreate/index.tsx
@@ -894,16 +894,19 @@ const RoyaltiesStep = (props: {
             const creatorStructs: Creator[] = [
               ...fixedCreators,
               ...creators,
-            ].map(
-              c =>
-                new Creator({
-                  address: new PublicKey(c.value),
-                  verified: c.value === wallet?.publicKey?.toBase58(),
-                  share:
-                    royalties.find(r => r.creatorKey === c.value)?.amount ||
-                    Math.round(100 / royalties.length),
-                }),
-            );
+            ].map(c => {
+              const address = new PublicKey(c.value);
+              return new Creator({
+                address,
+                verified:
+                  wallet !== undefined &&
+                  wallet.publicKey !== null &&
+                  address.equals(wallet.publicKey),
+                share:
+                  royalties.find(r => r.creatorKey === c.value)?.amount ||
+                  Math.round(100 / royalties.length),
+              });
+            });
 
             const share = creatorStructs.reduce(
               (acc, el) => (acc += el.share),

--- a/js/packages/web/src/views/artworks/index.tsx
+++ b/js/packages/web/src/views/artworks/index.tsx
@@ -21,7 +21,7 @@ export enum ArtworkViewState {
 export const ArtworksView = () => {
   const { connected, wallet } = useWallet();
   const ownedMetadata = useUserArts();
-  const createdMetadata = useCreatorArts(wallet?.publicKey?.toBase58() || '');
+  const createdMetadata = useCreatorArts(wallet?.publicKey ?? undefined);
   const { metadata, isLoading } = useMeta();
   const [activeKey, setActiveKey] = useState(ArtworkViewState.Metaplex);
   const breakpointColumnsObj = {

--- a/js/packages/web/src/views/auction/index.tsx
+++ b/js/packages/web/src/views/auction/index.tsx
@@ -227,7 +227,7 @@ const BidLine = (props: {
   const { bid, index, mint, isCancelled, isActive } = props;
   const { wallet } = useWallet();
   const bidder = bid.info.bidderPubkey.toBase58();
-  const isme = wallet?.publicKey?.toBase58() === bidder;
+  const isme = wallet?.publicKey?.equals(bid.info.bidderPubkey) ?? false;
 
   // Get Twitter Handle from address
   const connection = useConnection();

--- a/js/packages/web/src/views/auctionCreate/artSelector.tsx
+++ b/js/packages/web/src/views/auctionCreate/artSelector.tsx
@@ -66,7 +66,9 @@ export const ArtSelector = (props: ArtSelectorProps) => {
               onClick={open}
               close={() => {
                 setSelected(
-                  selected.filter(_ => _.metadata.pubkey.toBase58() !== key),
+                  selected.filter(_ =>
+                    _.metadata.pubkey.equals(m?.metadata.pubkey),
+                  ),
                 );
                 confirm();
               }}

--- a/js/packages/web/src/views/home/index.tsx
+++ b/js/packages/web/src/views/home/index.tsx
@@ -73,7 +73,14 @@ export const HomeView = () => {
         items = liveAuctions;
         break;
       case LiveAuctionViewState.Participated:
-        items = liveAuctions.concat(auctionsEnded).filter((m, idx) => m.myBidderMetadata?.info.bidderPubkey.toBase58() == wallet?.publicKey?.toBase58());
+        items = liveAuctions
+          .concat(auctionsEnded)
+          .filter(
+            (m, idx) =>
+              wallet !== undefined &&
+              wallet?.publicKey !== null &&
+              m.myBidderMetadata?.info.bidderPubkey.equals(wallet.publicKey),
+          );
         break;
       case LiveAuctionViewState.Resale:
         items = resaleAuctions;


### PR DESCRIPTION
Instead of calling pubKey.toBase58() === anotherPubKey.toBase58(), we can use the faster pubKey.equals(anotherPubKey). This avoids the costly casting and string comparison. This PR covers most but not all cases that were using the slower comparison method. 