### PR TITLE
Make the payer writeable in create_metadata_accounts

### DIFF
--- a/rust/token-metadata/program/src/instruction.rs
+++ b/rust/token-metadata/program/src/instruction.rs
@@ -268,7 +268,7 @@ pub fn create_metadata_accounts(
             AccountMeta::new(metadata_account, false),
             AccountMeta::new_readonly(mint, false),
             AccountMeta::new_readonly(mint_authority, true),
-            AccountMeta::new_readonly(payer, true),
+            AccountMeta::new(payer, true),
             AccountMeta::new_readonly(update_authority, update_authority_is_signer),
             AccountMeta::new_readonly(solana_program::system_program::id(), false),
             AccountMeta::new_readonly(sysvar::rent::id(), false),


### PR DESCRIPTION
This wallet (the payer) needs to be mutable because funds are going to be drawn from it during the processing of the instruction.

Having the `payer` declared as not writeable makes it impossible to use `create_metadata_accounts` for calling the token metadata program on-chain via CPI, for example.