### PR TITLE
[Fix] Ensure account before checking owner

### DIFF
--- a/js/packages/web/src/contexts/meta/processMetaData.ts
+++ b/js/packages/web/src/contexts/meta/processMetaData.ts
@@ -85,7 +85,7 @@ export const processMetaData: ProcessAccountsFunc = (
 };
 
 const isMetadataAccount = (account: AccountInfo<Buffer>) => {
-  return (account.owner as unknown as any) === METADATA_PROGRAM_ID;
+  return (account?.owner as unknown as any) === METADATA_PROGRAM_ID;
 };
 
 const isMetadataV1Account = (account: AccountInfo<Buffer>) =>


### PR DESCRIPTION
# Changes
Ensure there is an account before checking the owner. Currently, some accounts being processed are null which throw an error and prevent the auctions from loading.