### PR TITLE
Candy Machine Authority as a verified creator

### DIFF
--- a/rust/nft-candy-machine/src/lib.rs
+++ b/rust/nft-candy-machine/src/lib.rs
@@ -121,7 +121,7 @@ pub mod nft_candy_machine {
         for c in &config.data.creators {
             creators.push(spl_token_metadata::state::Creator {
                 address: c.address,
-                verified: false,
+                verified: if c.address==candy_machine.authority{true} else{false},
                 share: c.share,
             });
         }


### PR DESCRIPTION
This issue popped up when two candy machines were created from a single account. By implementing this, the creator can verify his own account if it is in the creators array. Then all the NFTs generated with the authority of the same Address will be verified.