### PR TITLE
Implemented a templated metadatas feature for the candymachine on-chain program operatable from CLI

### DIFF
--- a/js/packages/cli/src/commands/template.ts
+++ b/js/packages/cli/src/commands/template.ts
@@ -1,0 +1,104 @@
+import fs from "fs";
+import { createConfig, loadAnchorProgram, loadWalletKey } from "../helpers/accounts";
+import { PublicKey } from "@solana/web3.js";
+import BN from "bn.js";
+import { loadCache, saveCache } from "../helpers/cache";
+import log from "loglevel";
+import readline from "readline";
+
+export async function initializeTemplatedMetadataConfiguration(templatePath:string, uriTemplate:string, cacheName: string, env: string, keypair: string): Promise<boolean> {
+  if (uriTemplate == null) {
+    console.warn('Error: the URI template (--uri) is mandatory when generating templated metadatas')
+    process.exit(1)
+  }
+  const savedContent = loadCache(cacheName, env);
+  if (savedContent != null) {
+    const input = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout
+    });
+    await new Promise((resolve) => {
+      input.question(`An existing cache (${savedContent.program.uuid}) has been found, confirm overwrite? (y/[n])\n`, function(answer) {
+        if (answer == 'y') {
+          resolve(null);
+        } else {
+          process.exit(0)
+        }
+      })
+    });
+    input.close()
+  }
+  
+  if (!fs.existsSync(templatePath)) {
+    console.warn(`Error: template not found: ${templatePath}`)
+    return false
+  }
+  const templateContent = fs
+    .readFileSync(templatePath)
+    .toString()
+  const manifest = JSON.parse(templateContent);
+
+  if (manifest.name.indexOf('{i}') == -1) {
+    console.warn('Warning: your manifest name does not contain an {i} placehoder')
+  }
+  if (uriTemplate.indexOf('{i}') == -1) {
+    console.warn('Warning: your URI template does not contain an {i} placehoder')
+  }
+
+  // initialize config
+  log.info('initializing new config')
+  let cacheContent
+  try {
+    const walletKeyPair = loadWalletKey(keypair);
+    const anchorProgram = await loadAnchorProgram(walletKeyPair, env);
+
+    const res = await createConfig(anchorProgram, walletKeyPair, {
+      maxNumberOfLines: new BN(1), // only the template is stored on chain
+      symbol: manifest.symbol,
+      sellerFeeBasisPoints: manifest.seller_fee_basis_points,
+      isMutable: true,
+      maxSupply: new BN(0),
+      retainAuthority: true,
+      isTemplatedMetadata: true,
+      creators: manifest.properties.creators.map(creator => {
+        return {
+          address: new PublicKey(creator.address),
+          verified: true,
+          share: creator.share,
+        };
+      })
+    });
+    cacheContent = {
+      program: {
+        uuid: res.uuid,
+        config: res.config.toBase58()
+      },
+      isTemplated: true
+    };
+    log.info(`initialized config for a candy machine with publickey: ${res.config.toBase58()}`)
+
+    await anchorProgram.rpc.addConfigLines(
+      0,
+      [{
+        name: manifest.name,
+        uri: uriTemplate
+      }],
+      {
+        accounts: {
+          config: res.config,
+          authority: walletKeyPair.publicKey,
+        },
+        signers: [walletKeyPair],
+      },
+    )
+
+    saveCache(cacheName, env, cacheContent);
+  } catch (exx) {
+    log.error('Error deploying config to Solana network.', exx);
+    throw exx;
+  } finally {
+    saveCache(cacheName, env, cacheContent);
+  }
+  console.log(`Done.`);
+  return true;
+}

--- a/js/packages/cli/src/commands/upload.ts
+++ b/js/packages/cli/src/commands/upload.ts
@@ -89,6 +89,7 @@ export async function upload(files: string[], cacheName: string, env: string, ke
             isMutable: true,
             maxSupply: new BN(0),
             retainAuthority: true,
+            isTemplatedMetadata: false,
             creators: manifest.properties.creators.map(creator => {
               return {
                 address: new PublicKey(creator.address),

--- a/js/packages/cli/src/helpers/accounts.ts
+++ b/js/packages/cli/src/helpers/accounts.ts
@@ -23,6 +23,7 @@ export const createConfig = async function (
     isMutable: boolean;
     maxSupply: BN;
     retainAuthority: boolean;
+    isTemplatedMetadata: boolean;
     creators: {
       address: PublicKey;
       verified: boolean;

--- a/js/packages/cli/src/helpers/constants.ts
+++ b/js/packages/cli/src/helpers/constants.ts
@@ -21,7 +21,8 @@ export const CONFIG_ARRAY_START =
   8 + //max supply
   1 + //is mutable
   1 + // retain authority
-  4; // max number of lines;
+  4 + // max number of lines
+  1; // is templated
 export const CONFIG_LINE_SIZE = 4 + 32 + 4 + 200;
 
 export const CACHE_PATH = './.cache';


### PR DESCRIPTION
I'm kinda new to rust and the whole Solana ecosystem, don't hesitate to tell me if something needs to be changed.

Implemented a templated metadatas feature for the candymachine on-chain program operatable from CLI. See https://github.com/metaplex-foundation/metaplex/issues/382.

# How to test or use this feature

Considering the following `metadatas.json` file:

```
{
  "name": "Test #{i}",
  "symbol": "TST",
  "properties": {
    "creators": [
      { "address": "{redacted}", "share": 100 }
    ]
  }
}
```

```
ts-node cli initialize_templated_metadata metadatas.json -u 'https://test/{i}.json' -k {redacted}
```

Will output: 

```
starting templated metadatas configuration generation
initializing new config
wallet public key: {redacted}
initialized config for a candy machine with publickey: {redacted}
Done.
```

Then: 

```
ts-node cli create_candy_machine -p 0.00006 -n 20 -k {redacted}
```

Will create the "templated" candy machine:

```
wallet public key: {redacted}
create_candy_machine finished. candy machine pubkey: {redacted}
```

That we can then use to create token that will use metadatas generated by the defined template:

```
for i in {1..20}; do ts-node cli mint_one_token -k {redacted}; done
```

We can use tests from `token-metadata` on some of the created tokens to check the generation process: 

```
cargo run --bin spl-token-metadata-test-client show --mint 2KbeNBa2RT3R3BAN9SafoSHapsVv8aVfQb3WhUZs5UHq --keypair {redacted}
cargo run --bin spl-token-metadata-test-client show --mint 2KEMDZqkzZqYDDmmNdPXuWN4DyrPKHTnb5UUbSLifQ3P --keypair {redacted}
```

Will output: 

```
...
name: "Test #4\u{0}\u{0}\u{0}...",
uri: "https://test/4.json\u{0}\u{0}\u{0}...",
...
name: "Test #7\u{0}\u{0}...",
uri: "https://test/7.json\u{0}\u{0}...",
...
```

A candy machine implementing this feature as been deployed here for testing purpose on devnet: `3gvU2gogD8LoYcuSH3rSDbfCqrW6UeT78o4YX822TrY4`.

Thanks for reading!