### PR TITLE
Improve doc comments

### DIFF
--- a/rust/auction/program/src/instruction.rs
+++ b/rust/auction/program/src/instruction.rs
@@ -56,6 +56,9 @@ pub enum AuctionInstruction {
     StartAuction(StartAuctionArgs),
 
     /// Update the authority for an auction account.
+    ///   0. `[writable]` auction
+    ///   1. `[signer]` authority
+    ///   2. `[]` newAuthority
     SetAuthority,
 
     /// Place a bid on a running auction.

--- a/rust/auction/program/src/instruction.rs
+++ b/rust/auction/program/src/instruction.rs
@@ -56,7 +56,7 @@ pub enum AuctionInstruction {
     StartAuction(StartAuctionArgs),
 
     /// Update the authority for an auction account.
-    ///   0. `[writable]` auction
+    ///   0. `[writable]` auction (pda of ['auction', program id, resource id])
     ///   1. `[signer]` authority
     ///   2. `[]` newAuthority
     SetAuthority,

--- a/rust/token-metadata/program/src/instruction.rs
+++ b/rust/token-metadata/program/src/instruction.rs
@@ -145,7 +145,6 @@ pub enum MetadataInstruction {
     DeprecatedCreateReservationList,
 
     /// Sign a piece of metadata that has you as an unverified creator so that it is now verified.
-    ///
     ///   0. `[writable]` Metadata (pda of ['metadata', program id, mint id])
     ///   1. `[signer]` Creator
     SignMetadata,

--- a/rust/token-metadata/program/src/instruction.rs
+++ b/rust/token-metadata/program/src/instruction.rs
@@ -144,8 +144,8 @@ pub enum MetadataInstruction {
     ///   7. `[]` Rent info
     DeprecatedCreateReservationList,
 
-    // Sign a piece of metadata that has you as an unverified creator so that it is now verified.
-    //
+    /// Sign a piece of metadata that has you as an unverified creator so that it is now verified.
+    ///
     ///   0. `[writable]` Metadata (pda of ['metadata', program id, mint id])
     ///   1. `[signer]` Creator
     SignMetadata,


### PR DESCRIPTION
This PR:

1. Documents the `SetAuthority` instruction of the `auction` program (based on what I see in [`pub fn set_authority_instruction`](https://github.com/metaplex-foundation/metaplex/blob/09d323accd8c494454c5b94fc18ef04a71212e74/rust/auction/program/src/instruction.rs#L115)
2. Fixes the doc on the `SignMetadata` instruction of the `token-metadata` program (replacing `//` with the more appropriate `///`)