### PR TITLE
fix key error for attribute list on art view

### DIFF
--- a/js/packages/web/src/views/art/index.tsx
+++ b/js/packages/web/src/views/art/index.tsx
@@ -207,7 +207,7 @@ export const ArtView = () => {
                   grid={{ column: 4 }}
                 >
                   {attributes.map(attribute =>
-                    <List.Item>
+                    <List.Item key={attribute.trait_type}>
                       <Card title={attribute.trait_type}>{attribute.value}</Card>
                     </List.Item>
                   )}


### PR DESCRIPTION
![Screen Shot 2021-09-19 at 2 34 53 PM](https://user-images.githubusercontent.com/524896/133938966-dc1b6d2c-a3d4-439a-a8a3-0dfd523278bc.png)
Add key attribute to fix error when art view rendered with attribute list