### PR TITLE
add key to attributes list items to fix key missing error

### DIFF
--- a/js/packages/web/src/views/art/index.tsx
+++ b/js/packages/web/src/views/art/index.tsx
@@ -223,7 +223,7 @@ export const ArtView = () => {
                 <div className="info-header">Attributes</div>
                 <List size="large" grid={{ column: 4 }}>
                   {attributes.map(attribute => (
-                    <List.Item>
+                    <List.Item key={attribute.trait_type}>
                       <Card title={attribute.trait_type}>
                         {attribute.value}
                       </Card>


### PR DESCRIPTION
Fixes this error when rendering the art view with an attributes list

![Screen Shot 2021-09-19 at 2 34 53 PM](https://user-images.githubusercontent.com/524896/133939522-5904ddcd-3c7e-497e-a0f6-873417863f52.png)