### PR TITLE
Add click to copy functionality for bidder lines

### DIFF
--- a/js/packages/web/src/components/ClickToCopy/index.tsx
+++ b/js/packages/web/src/components/ClickToCopy/index.tsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useState } from 'react';
+
+const CopyIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    className="feather feather-copy"
+  >
+    <rect
+      stroke="currentColor"
+      x="9"
+      y="9"
+      width="13"
+      height="13"
+      rx="2"
+      ry="2"
+    ></rect>
+    <path
+      stroke="currentColor"
+      d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"
+    ></path>
+  </svg>
+);
+
+const Checkmark = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    className="feather feather-check"
+  >
+    <polyline points="20 6 9 17 4 12"></polyline>
+  </svg>
+);
+
+export const ClickToCopy = ({
+  copyText,
+  className,
+}: {
+  copyText: string;
+  className: string;
+}) => {
+  const [clicked, setClicked] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setClicked(false);
+    }, 3000);
+    return () => clearTimeout(timer);
+  }, [clicked]);
+
+  const onClick = () => {
+    navigator.clipboard.writeText(copyText);
+    setClicked(true);
+  };
+
+  return (
+    <div className={className} onClick={onClick} title="Click to copy pubkey">
+      {clicked ? <Checkmark /> : <CopyIcon />}
+    </div>
+  );
+};

--- a/js/packages/web/src/styles/app.less
+++ b/js/packages/web/src/styles/app.less
@@ -155,6 +155,20 @@ code {
   margin-left: -12px !important;
 }
 
+.pubkey-row {
+  line-height: 30px;
+}
+
+.copy-pubkey {
+  height: 100%;
+  cursor: pointer;
+  margin-left: 10px;
+  color: @background-color-secondary;
+  :hover {
+    color: @text-color;
+  }
+}
+
 .creator-name {
   padding-left: 10px;
 }

--- a/js/packages/web/src/views/auction/index.tsx
+++ b/js/packages/web/src/views/auction/index.tsx
@@ -34,6 +34,7 @@ import useWindowDimensions from '../../utils/layout';
 import { CheckOutlined } from '@ant-design/icons';
 import { useMemo } from 'react';
 import { ArtType } from '../../types';
+import { ClickToCopy  } from '../../components/ClickToCopy';
 
 export const AuctionItem = ({
   item,
@@ -331,13 +332,19 @@ const BidLine = (props: {
             address={bidder}
           />{' '}
           {bidderTwitterHandle ? (
-            <a
-              target="_blank"
-              title={shortenAddress(bidder)}
-              href={`https://twitter.com/${bidderTwitterHandle}`}
-            >{`@${bidderTwitterHandle}`}</a>
+            <Row className="pubkey-row"> 
+              <a
+                target="_blank"
+                title={shortenAddress(bidder)}
+                href={`https://twitter.com/${bidderTwitterHandle}`}
+              >{`@${bidderTwitterHandle}`}</a>
+              <ClickToCopy className="copy-pubkey" copyText={bidder as string} />
+            </Row>
           ) : (
-            shortenAddress(bidder)
+            <Row className="pubkey-row"> 
+              {shortenAddress(bidder)}
+              <ClickToCopy className="copy-pubkey" copyText={bidder as string} />
+            </Row>
           )}
           {isme && <span style={{ color: '#6479f6' }}>&nbsp;(you)</span>}
         </Row>


### PR DESCRIPTION
This PR adds a click to copy button to the  bidder line component. Numerous Holaplex storefront owners want to air drop consolation prizes to runners-up in their auctions. The truncation on bidlines was preventing them from doing that. The click-to-copy functionality helps anyone easily grab a pubkey from any auction in a store. This is already live on Holaplex stores. 

Thanks Damian Rebman for design input. Looks like this.

![image](https://user-images.githubusercontent.com/5935947/134054267-26b031b2-3006-48ea-91b5-e395393fe83d.png)
