### PR TITLE
Power Speed Run Based on The Store Owner

### DIFF
--- a/js/packages/common/src/contexts/meta/meta.tsx
+++ b/js/packages/common/src/contexts/meta/meta.tsx
@@ -19,7 +19,7 @@ const MetaContext = React.createContext<MetaContextState>({
 
 export function MetaProvider({ children = null as any }) {
   const connection = useConnection();
-  const { isReady, storeAddress } = useStore();
+  const { isReady, storeAddress, ownerAddress } = useStore();
   const searchParams = useQuerySearch();
   const all = searchParams.get('all') == 'true';
 
@@ -63,7 +63,7 @@ export function MetaProvider({ children = null as any }) {
 
       const nextState = !USE_SPEED_RUN
         ? await loadAccounts(connection, all)
-        : await limitedLoadAccounts(connection);
+        : await limitedLoadAccounts(ownerAddress as string, connection);
 
       console.log('------->Query finished');
 

--- a/js/packages/common/src/contexts/meta/processAuctions.ts
+++ b/js/packages/common/src/contexts/meta/processAuctions.ts
@@ -92,7 +92,7 @@ export const processAuctions: ProcessAccountsFunc = (
 };
 
 const isAuctionAccount: CheckAccountFunc = account =>
-  (account.owner as unknown as any) === AUCTION_ID;
+  (account?.owner as unknown as any) === AUCTION_ID;
 
 const isExtendedAuctionAccount: CheckAccountFunc = account =>
   account.data.length === MAX_AUCTION_DATA_EXTENDED_SIZE;

--- a/js/packages/common/src/contexts/meta/processMetaplexAccounts.ts
+++ b/js/packages/common/src/contexts/meta/processMetaplexAccounts.ts
@@ -168,7 +168,7 @@ export const processMetaplexAccounts: ProcessAccountsFunc = async (
 };
 
 const isMetaplexAccount = (account: AccountInfo<Buffer>) =>
-  (account.owner as unknown as any) === METAPLEX_ID;
+  (account?.owner as unknown as any) === METAPLEX_ID;
 
 const isAuctionManagerV1Account = (account: AccountInfo<Buffer>) =>
   account.data[0] === MetaplexKey.AuctionManagerV1;

--- a/js/packages/common/src/contexts/store.tsx
+++ b/js/packages/common/src/contexts/store.tsx
@@ -18,6 +18,8 @@ interface StoreConfig {
   isReady: boolean;
   // recalculate store address for specified owner address
   setStoreForOwner: (ownerAddress?: string) => Promise<string | undefined>;
+
+  ownerAddress?: StringPublicKey;
 }
 
 export const StoreContext = createContext<StoreConfig>(null!);
@@ -62,7 +64,7 @@ export const StoreProvider: FC<{
   }, [initOwnerAddress]);
 
   return (
-    <StoreContext.Provider value={{ ...store, setStoreForOwner, isConfigured }}>
+    <StoreContext.Provider value={{ ...store, setStoreForOwner, isConfigured, ownerAddress }}>
       {children}
     </StoreContext.Provider>
   );


### PR DESCRIPTION
### Goal
All stores use speed run when the only NFTs and auctions the storefront should display are the storefront owners.

### Changes
- Assemble auction and metadata queries based on the store owner address.

### Tasks
- [X] Replace WHITELISTED_METATA with 5 filtered queries to get metadata from token metatdata program based on the creators field.
- [ ] Replace WHITELISTED_AUCTION_MANAGER with a filtered query to metaplex program based on the store address. [AuctionManagerV2 Struct](https://github.com/metaplex-foundation/metaplex/blob/08cce01bc8ed08ed683a997f2a1e16e2579fcaa9/rust/metaplex/program/src/state.rs#L196)
- [ ] Replace WHITELISTED_AUCTION after querying auction managers loop through results and fetch auction based on auction field set on auction manager.
- [ ] Replace  AUCTION_TO_METADATA  
- [ ] Replace AUCTION_TO_VAULT

### Screen Shots
![image](https://user-images.githubusercontent.com/2388118/134186570-78c01b92-919d-4247-8743-6b6913cf3c6e.png)


### Questions
- Most storefronts only have 1 creator which is the store owner but storefronts are capable of displaying metadata for any whitelisted creator. However, whitelisted creators are a pda account whose address is derived from store addresss and wallet address. This requires comparing the address of all accounts in Metaplex and comparing it with the computed address for the whitelisted creator account. Is this assessment correct? Is there a means of using memcmp filters to find whitelisted creators based on the store address?
- I'm testing using the same owner address as https://bhgames.github.io/metaplex#/artworks. This version of the code is pulling up "Simple test" and not "Pit and Viper". What is off?
- Any of the Tasks with no strat for replacing our are still unknown. Ideas welcomed!