### PR TITLE
Add sanity check before upload

### DIFF
--- a/js/packages/cli/src/helpers/accounts.ts
+++ b/js/packages/cli/src/helpers/accounts.ts
@@ -34,6 +34,19 @@ export const createConfig = async function (
   const configAccount = Keypair.generate();
   const uuid = uuidFromConfigPubkey(configAccount.publicKey);
 
+  if (!configData.creators || configData.creators.length === 0) {
+    throw new Error(`Invalid config, there must be at least one creator.`);
+  }
+
+  const totalShare = (configData.creators || []).reduce(
+    (acc, curr) => acc + curr.share,
+    0,
+  );
+
+  if (totalShare !== 100) {
+    throw new Error(`Invalid config, creators shares must add up to 100`);
+  }
+
   return {
     config: configAccount.publicKey,
     uuid,


### PR DESCRIPTION
Background:

I managed to initiate the upload with jsons which contain an empty creators array. The consquence was that the CM was set up without an issue and when trying to mint will throw an error, with no obvious way to retrieve the funds or fix. The error thrown was sth like "Creator shares must add up to 100". 

In order to avoid having funds nuked like this (in my case almost 17 SOL)  I would like to propose checking this case.