### PR TITLE
Fix resolution of duplicate react types

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -73,5 +73,8 @@
     "ts-jest": "^24.0.0",
     "ts-node": "^9.0.0",
     "typescript": "^4.1.3"
+  },
+  "resolutions": {
+    "@types/react": "17.0.21"
   }
 }

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -4315,16 +4315,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*":
-  version "17.0.9"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.9.tgz#1147fb520024a62c9b3841f5cb4db89b73ddb87f"
-  integrity sha512-2Cw7FvevpJxQrCb+k5t6GH1KIvmadj5uBbjPaLlJB/nZWUj56e1ZqcD6zsoMFB47MsJUTFl9RJ132A7hb3QFJA==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@^17.0.0", "@types/react@^17.0.16":
+"@types/react@*", "@types/react@17.0.21", "@types/react@^17.0.0", "@types/react@^17.0.16":
   version "17.0.21"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.21.tgz#069c43177cd419afaab5ce26bb4e9056549f7ea6"
   integrity sha512-GzzXCpOthOjXvrAUFQwU/svyxu658cwu00Q9ugujS4qc1zXgLFaO0kS2SLOaMWLt2Jik781yuHCWB7UcYdGAeQ==


### PR DESCRIPTION
pulled from [here](https://stackoverflow.com/questions/52399839/duplicate-identifier-librarymanagedattributes), but restores the ability to successfully run `yarn build` after a fresh pull from yarn.

digging into the `yarn.lock`, looks like a new version of `@solana/wallet-adapter-material-ui` which has `@types/react` tied to [a specific version](https://github.com/solana-labs/wallet-adapter/blob/7eb8ec45a15e555fd9ace4ac48048380f7162b61/packages/ui/material-ui/package.json#L33), but in most cases this should be declared as `'@types/react': "*"` to let the consuming package (in this case, metaplex) choose which version. this is also [an issue](https://github.com/solana-labs/wallet-adapter/blob/7eb8ec45a15e555fd9ace4ac48048380f7162b61/packages/ui/ant-design/package.json#L33) with `@solana/wallet-adapter-ant-design` /cc @jordansexton 

in any case, setting the resolution here forces packages to refer to a single version of `@types/react`, which resolves the issue with typescript that comes up when you run `yarn build`.