### PR TITLE
fix subscription accounts not being processed

### DIFF
--- a/js/packages/common/src/contexts/meta/onChangeAccount.ts
+++ b/js/packages/common/src/contexts/meta/onChangeAccount.ts
@@ -10,10 +10,16 @@ export const onChangeAccount =
   ): ProgramAccountChangeCallback =>
   async info => {
     const pubkey = pubkeyToString(info.accountId);
+    const account =  info.accountInfo
+
     await process(
       {
         pubkey,
-        account: info.accountInfo,
+        account: {
+          ...account,
+          // to make sure these accounts get processed by processAuctions, processVaultData, etc
+          owner: account.owner.toBase58() as unknown as any
+        },
       },
       setter,
       all,


### PR DESCRIPTION
All the processors `(processAuctions, processMetaData, processVaultData, processMetaplexAccounts)` want the owner to be in string format in order to verify if they belong to any.

This PR fixes that for accounts coming via `onProgramAccountChange`