### PR TITLE
Changed mint_one_token to premint_token with a number flag for looping

### DIFF
--- a/js/packages/cli/src/candy-machine-cli.ts
+++ b/js/packages/cli/src/candy-machine-cli.ts
@@ -577,14 +577,34 @@ programCommand('update_candy_machine')
     log.info('updated_candy_machine finished', tx);
   });
 
-programCommand('mint_one_token').action(async (directory, cmd) => {
-  const { keypair, env, cacheName } = cmd.opts();
+programCommand('premint_token')
+  .option(
+    '-n --number <number>',
+    'Premint NFTs based on the number entered starting from 0.json or the last minted JSON  if the command has already ran.',
+  )
+  .action(async (directory, cmd) => {
+    const { keypair, env, cacheName, number } = cmd.opts();
 
-  const cacheContent = loadCache(cacheName, env);
-  const configAddress = new PublicKey(cacheContent.program.config);
-  const tx = await mint(keypair, env, configAddress);
+    const cacheContent = loadCache(cacheName, env);
+    const configAddress = new PublicKey(cacheContent.program.config);
+    if (number >= 1) {
+      for (let num = 0; num < number; num++) {
+        const tx = await mint(keypair, env, configAddress);
 
-  log.info('mint_one_token finished', tx);
+        log.info('Done', tx);
+        log.info(num);
+      }
+    } else if (number <= 0) {
+      log.info('Number must be greater that 0');
+      return;
+    }
+
+    if (!number) {
+      const tx = await mint(keypair, env, configAddress);
+
+      log.info('Done', tx);
+      return;
+    }
 });
 
 programCommand('sign')


### PR DESCRIPTION
I'm working on a project right now and developed this little for loop nested inside of an if statement that reads a number entered in on the CLI. If no number is entered in, it mints one NFT by default. However, you can control the amount you want minted by using the -n flag such as -n 100 to mint 100 NFTs either starting from 0.JSON if this is your first time running it...or it picks up wherever you left off on your last mint. I added a small counter as well so you can see visually how many are being minted in the CLI in the event there's some sort of error that stops it and you need to start over, but you don't know how many you've already done because before there was no counter.