### PR TITLE
Improve auctions load by pulling related metadata

### DIFF
--- a/js/packages/common/src/contexts/meta/loadAccounts.ts
+++ b/js/packages/common/src/contexts/meta/loadAccounts.ts
@@ -305,6 +305,8 @@ export const loadAccounts = async (connection: Connection) => {
     auctionManagersByAuction: state.auctionManagersByAuction,
   }).then(forEachAccount(processAuctions));
 
+  console.log('Metadata size', state.metadata.length);
+
   return state;
 };
 

--- a/js/packages/common/src/contexts/meta/loadAccounts.ts
+++ b/js/packages/common/src/contexts/meta/loadAccounts.ts
@@ -38,6 +38,7 @@ import { getEmptyMetaState } from './getEmptyMetaState';
 import { getMultipleAccounts } from '../accounts/getMultipleAccounts';
 import { getProgramAccounts } from './web3';
 import { createPipelineExecutor } from './createPipelineExecutor';
+import { pullAuctions } from './pullAuctions';
 
 export const USE_SPEED_RUN = false;
 const WHITELISTED_METADATA = ['98vYFjBYS9TguUMWQRPjy2SZuxKuUMcqR4vnQiLjZbte'];
@@ -275,10 +276,6 @@ export const loadAccounts = async (connection: Connection) => {
     getProgramAccounts(connection, VAULT_ID).then(
       forEachAccount(processVaultData),
     );
-  const loadAuctions = () =>
-    getProgramAccounts(connection, AUCTION_ID).then(
-      forEachAccount(processAuctions),
-    );
   const loadMetaplex = () =>
     getProgramAccounts(connection, METAPLEX_ID).then(
       forEachAccount(processMetaplexAccounts),
@@ -298,13 +295,15 @@ export const loadAccounts = async (connection: Connection) => {
   const loading = [
     loadCreators().then(loadMetadata).then(loadEditions),
     loadVaults(),
-    loadAuctions(),
     loadMetaplex(),
   ];
 
   await Promise.all(loading);
 
-  console.log('Metadata size', state.metadata.length);
+  await pullAuctions({
+    connection,
+    auctionManagersByAuction: state.auctionManagersByAuction,
+  }).then(forEachAccount(processAuctions));
 
   return state;
 };

--- a/js/packages/common/src/contexts/meta/pullAuctions.ts
+++ b/js/packages/common/src/contexts/meta/pullAuctions.ts
@@ -1,0 +1,78 @@
+import { Connection } from '@solana/web3.js';
+
+import { getMultipleAccounts } from '../accounts/getMultipleAccounts';
+import { AuctionManagerV1, AuctionManagerV2 } from '../../models';
+import { ParsedAccount } from '../accounts/types';
+import { AccountAndPubkey } from './types';
+
+type AuctionManagerByAuction = Record<
+  string,
+  ParsedAccount<AuctionManagerV1 | AuctionManagerV2>
+>;
+
+interface IPullAuctionsParams {
+  connection: Connection;
+  auctionManagersByAuction: AuctionManagerByAuction;
+}
+
+export const pullAuctions = async ({
+  connection,
+  auctionManagersByAuction,
+}: IPullAuctionsParams) => {
+  const IDS_PER_CHUNK = 100;
+  const auctionIdsChunks = [
+    ...chunks(
+      getAuctionsIdsByAuctionManager(auctionManagersByAuction),
+      IDS_PER_CHUNK,
+    ),
+  ];
+
+  const auctionsChunks = await Promise.all(
+    auctionIdsChunks.map(ids =>
+      pullAuctionsByAuctionManager({ ids, connection }),
+    ),
+  );
+
+  return auctionsChunks.flat();
+};
+
+const getAuctionsIdsByAuctionManager = (
+  auctionManagersByAuction: AuctionManagerByAuction,
+) =>
+  Object.values(auctionManagersByAuction).reduce((ids, { info }) => {
+    ids.push(info.auction);
+
+    if (isAuctionManagerV2(info) && info?.auctionDataExtended) {
+      ids.push(info.auctionDataExtended);
+    }
+
+    return ids;
+  }, [] as string[]);
+
+const pullAuctionsByAuctionManager = ({
+  connection,
+  ids,
+}: {
+  connection: Connection;
+  ids: string[];
+}): Promise<AccountAndPubkey[]> => {
+  return getMultipleAccounts(connection, ids, 'single').then(
+    ({ keys, array }) =>
+      keys.map((pubkey, i) => ({
+        pubkey,
+        account: array[i],
+      })),
+  );
+};
+
+function* chunks(array: string[], chunkSize: number) {
+  for (let i = 0; i < array.length; i += chunkSize) {
+    yield array.slice(i, i + chunkSize);
+  }
+}
+
+const isAuctionManagerV2 = (
+  auctionManager: AuctionManagerV1 | AuctionManagerV2,
+): auctionManager is AuctionManagerV2 => {
+  return (auctionManager as AuctionManagerV2).auctionDataExtended !== undefined;
+};


### PR DESCRIPTION
The auction manager has **auction** and **auctionDataExtended** fields in his info. Since the auction manager is being filtered by the store id, we can use these ids to load related auctions.
By having these ids, we can utilize **getMultipleAccounts** to fetch related auctions.
This will clean up the cache and improve loading & rendering speed.

