### PR TITLE
support current version of node.js

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -8,7 +8,7 @@
   "keywords": [],
   "license": "Apache-2.0",
   "engines": {
-    "node": "~14.17"
+    "node": ">=14.17"
   },
   "scripts": {
     "bootstrap": "lerna link && lerna bootstrap",


### PR DESCRIPTION
[Current version of node is 16](https://nodejs.org/en/)

Any reason to remain pinned to node 14?
