### PR TITLE
Candy machine cli show command bug fix

### DIFF
--- a/js/packages/cli/src/candy-machine-cli.ts
+++ b/js/packages/cli/src/candy-machine-cli.ts
@@ -374,6 +374,7 @@ programCommand('show')
       //@ts-ignore
       log.info(
         'tokenMint: ',
+        //@ts-ignore
         machine.tokenMint ? machine.tokenMint.toBase58() : null,
       );
       //@ts-ignore

--- a/js/packages/cli/src/candy-machine-cli.ts
+++ b/js/packages/cli/src/candy-machine-cli.ts
@@ -372,7 +372,10 @@ programCommand('show')
       //@ts-ignore
       log.info('wallet: ', machine.wallet.toBase58());
       //@ts-ignore
-      log.info('tokenMint: ', machine.tokenMint.toBase58());
+      log.info(
+        'tokenMint: ',
+        machine.tokenMint ? machine.tokenMint.toBase58() : null,
+      );
       //@ts-ignore
       log.info('config: ', machine.config.toBase58());
       //@ts-ignore
@@ -398,7 +401,7 @@ programCommand('show')
     );
     log.info('...Config...');
     //@ts-ignore
-    log.info('authority: ', config.authority);
+    log.info('authority: ', config.authority.toBase58());
     //@ts-ignore
     log.info('symbol: ', config.data.symbol);
     //@ts-ignore


### PR DESCRIPTION
Handle edge case where tokenMint is null while running `show` command with candy-machine-cli 

Also, stringify  config authority for easier readability.