### PR TITLE
[Fix] Arweave assets that aren't immediately available are cached as not found forever

### DIFF
--- a/js/packages/web/src/hooks/useArt.ts
+++ b/js/packages/web/src/hooks/useArt.ts
@@ -94,6 +94,7 @@ export const useCachedImage = (uri: string, cacheMesh?: boolean) => {
     }
 
     const result = cachedImages.get(uri);
+
     if (result) {
       setCachedBlob(result);
       return;
@@ -101,11 +102,19 @@ export const useCachedImage = (uri: string, cacheMesh?: boolean) => {
 
     (async () => {
       let response: Response;
+      let blob: Blob;
       try {
         response = await fetch(uri, { cache: 'force-cache' });
+
+        blob = await response.blob();
+
+        if (blob.size === 0) {
+          throw new Error('No content');
+        }
       } catch {
         try {
           response = await fetch(uri, { cache: 'reload' });
+          blob = await response.blob();
         } catch {
           // If external URL, just use the uri
           if (uri?.startsWith('http')) {
@@ -116,7 +125,11 @@ export const useCachedImage = (uri: string, cacheMesh?: boolean) => {
         }
       }
 
-      const blob = await response.blob();
+      if (blob.size === 0) {
+        setIsLoading(false);
+        return;
+      }
+
       if (cacheMesh) {
         // extra caching for meshviewer
         Cache.enabled = true;


### PR DESCRIPTION
### Issue

Though Arweave accepts file uploads and returns an ID the files may still not be available for download. When an artist first creates an NFT and is sent to the show page If the asset isn't available it will cached forever as a 404 because the catch logic doesn't trigger to re-fetch with no cache.

### Background
Arweave links that are broken first send a redirect and then respond with 202 but no content.  Check the blob size and if its 0 then stop loading and dont save to the cache so it trys again on next load.

### Fix
Get the blob and check its size. If it's empty (which is what it will be in the case of 500 or 202 from arweave server) don't save it to the cache..

### Screenshots

![Screenshot from 2021-09-30 15-41-22](https://user-images.githubusercontent.com/2388118/135544989-21b23c75-31d2-4f19-9f95-f0bf1ac3962b.png)
_In the case of our cdn see the first cached query and then next without._

![Screenshot from 2021-09-30 16-09-33](https://user-images.githubusercontent.com/2388118/135545026-7ff70599-cc44-4a9b-ad44-e7d09f914d1a.png)
_Example of 202 response from arweave but no content_