### PR TITLE
[Fix] Instant sale purchasing

### DIFF
--- a/js/packages/common/src/contexts/meta/loadAccounts.ts
+++ b/js/packages/common/src/contexts/meta/loadAccounts.ts
@@ -1030,7 +1030,7 @@ export const initMetadata = async (
   }
 };
 
-export const loadMultipleAccounts = async (
+export const loadMultipleAccountsIntoMetaState = async (
   conn: Connection,
   keys: StringPublicKey[],
   commitment: string,

--- a/js/packages/common/src/contexts/meta/meta.tsx
+++ b/js/packages/common/src/contexts/meta/meta.tsx
@@ -12,7 +12,6 @@ import { merge } from 'lodash';
 import { MetaContextState, MetaState } from './types';
 import { useConnection } from '../connection';
 import { useStore } from '../store';
-import { merge } from 'lodash';
 import { AuctionData, BidderMetadata, BidderPot } from '../../actions';
 import {
   pullAuctionSubaccounts,
@@ -25,10 +24,17 @@ import { StringPublicKey, TokenAccount, useUserAccounts } from '../..';
 const MetaContext = React.createContext<MetaContextState>({
   ...getEmptyMetaState(),
   isLoading: false,
-  // @ts-ignore
-  update: () => [AuctionData, BidderMetadata, BidderPot],
+  pullAllMetadata: () => {
+    throw new Error('must implement')
+  },
+  pullBillingPage: (_: StringPublicKey) => {
+    throw new Error('must implement')
+  },
+  pullAuctionPage: (_: StringPublicKey) => {
+    throw new Error('must implement')
+  },
   patchState: () => {
-    throw new Error('unreachable');
+    throw new Error('must implement');
   },
 });
 
@@ -288,40 +294,10 @@ export function MetaProvider({ children = null as any }) {
     return subscribeAccountsChange(connection, () => state, setState);
   }, [connection, setState, isLoading, state]);
 
-  // TODO: fetch names dynamically
-  // TODO: get names for creators
-  // useEffect(() => {
-  //   (async () => {
-  //     const twitterHandles = await connection.getProgramAccounts(NAME_PROGRAM_ID, {
-  //      filters: [
-  //        {
-  //           dataSize: TWITTER_ACCOUNT_LENGTH,
-  //        },
-  //        {
-  //          memcmp: {
-  //           offset: VERIFICATION_AUTHORITY_OFFSET,
-  //           bytes: TWITTER_VERIFICATION_AUTHORITY.toBase58()
-  //          }
-  //        }
-  //      ]
-  //     });
-
-  //     const handles = twitterHandles.map(t => {
-  //       const owner = new PublicKey(t.account.data.slice(32, 64));
-  //       const name = t.account.data.slice(96, 114).toString();
-  //     });
-
-  //     console.log(handles);
-
-  //   })();
-  // }, [whitelistedCreatorsByCreator]);
-
   return (
     <MetaContext.Provider
       value={{
         ...state,
-        // @ts-ignore
-        update,
         pullAuctionPage,
         pullAllMetadata,
         pullBillingPage,

--- a/js/packages/common/src/contexts/meta/meta.tsx
+++ b/js/packages/common/src/contexts/meta/meta.tsx
@@ -12,6 +12,7 @@ import { merge } from 'lodash';
 import { MetaContextState, MetaState } from './types';
 import { useConnection } from '../connection';
 import { useStore } from '../store';
+import { merge } from 'lodash';
 import { AuctionData, BidderMetadata, BidderPot } from '../../actions';
 import {
   pullAuctionSubaccounts,

--- a/js/packages/common/src/contexts/meta/meta.tsx
+++ b/js/packages/common/src/contexts/meta/meta.tsx
@@ -8,6 +8,7 @@ import {
   pullYourMetadata,
   USE_SPEED_RUN,
 } from './loadAccounts';
+import { merge } from 'lodash';
 import { MetaContextState, MetaState } from './types';
 import { useConnection } from '../connection';
 import { useStore } from '../store';
@@ -25,6 +26,9 @@ const MetaContext = React.createContext<MetaContextState>({
   isLoading: false,
   // @ts-ignore
   update: () => [AuctionData, BidderMetadata, BidderPot],
+  patchState: () => {
+    throw new Error('unreachable');
+  },
 });
 
 export function MetaProvider({ children = null as any }) {
@@ -241,6 +245,14 @@ export function MetaProvider({ children = null as any }) {
     }
   }
 
+  const patchState: MetaContextState['patchState'] = temp => {
+    const newState = merge({}, state, temp);
+    newState.store = temp.store ?? state.store;
+    setState(newState);
+
+    return newState;
+  };
+
   useEffect(() => {
     //@ts-ignore
     if (window.loadingData) {
@@ -314,6 +326,7 @@ export function MetaProvider({ children = null as any }) {
         pullAuctionPage,
         pullAllMetadata,
         pullBillingPage,
+        patchState,
         isLoading,
       }}
     >

--- a/js/packages/common/src/contexts/meta/meta.tsx
+++ b/js/packages/common/src/contexts/meta/meta.tsx
@@ -250,8 +250,6 @@ export function MetaProvider({ children = null as any }) {
     const newState = merge({}, state, temp);
     newState.store = temp.store ?? state.store;
     setState(newState);
-
-    return newState;
   };
 
   useEffect(() => {

--- a/js/packages/common/src/contexts/meta/processAuctions.ts
+++ b/js/packages/common/src/contexts/meta/processAuctions.ts
@@ -16,7 +16,7 @@ import { ParsedAccount } from '../accounts';
 import { cache } from '../accounts';
 import { CheckAccountFunc, ProcessAccountsFunc } from './types';
 
-export const processAuctions: ProcessAccountsFunc = (
+export const processAuctions: ProcessAccountsFunc = async (
   { account, pubkey },
   setter,
 ) => {

--- a/js/packages/common/src/contexts/meta/processVaultData.ts
+++ b/js/packages/common/src/contexts/meta/processVaultData.ts
@@ -10,7 +10,7 @@ import { VAULT_ID, pubkeyToString } from '../../utils';
 import { ParsedAccount } from '../accounts/types';
 import { ProcessAccountsFunc } from './types';
 
-export const processVaultData: ProcessAccountsFunc = (
+export const processVaultData: ProcessAccountsFunc = async (
   { account, pubkey },
   setter,
 ) => {

--- a/js/packages/common/src/contexts/meta/types.ts
+++ b/js/packages/common/src/contexts/meta/types.ts
@@ -96,7 +96,7 @@ export interface MetaContextState extends MetaState {
   pullAuctionPage: (auctionAddress: StringPublicKey) => Promise<MetaState>;
   pullBillingPage: (auctionAddress: StringPublicKey) => void;
   pullAllMetadata: () => void;
-  patchState: (state: Partial<MetaState>) => MetaState;
+  patchState: (state: Partial<MetaState>) => void;
 }
 
 export type AccountAndPubkey = {

--- a/js/packages/common/src/contexts/meta/types.ts
+++ b/js/packages/common/src/contexts/meta/types.ts
@@ -86,15 +86,17 @@ export interface MetaContextState extends MetaState {
   update: (
     auctionAddress?: any,
     bidderAddress?: any,
-  ) => [
-    ParsedAccount<AuctionData>,
-    ParsedAccount<BidderPot>,
-    ParsedAccount<BidderMetadata>,
-  ];
+  ) => Promise<
+    [
+      ParsedAccount<AuctionData>,
+      ParsedAccount<BidderPot>,
+      ParsedAccount<BidderMetadata>,
+    ]
+  >;
   pullAuctionPage: (auctionAddress: StringPublicKey) => Promise<MetaState>;
   pullBillingPage: (auctionAddress: StringPublicKey) => void;
-
   pullAllMetadata: () => void;
+  patchState: (state: Partial<MetaState>) => MetaState;
 }
 
 export type AccountAndPubkey = {
@@ -111,7 +113,7 @@ export type UpdateStateValueFunc<T = void> = (
 export type ProcessAccountsFunc = (
   account: PublicKeyStringAndAccount<Buffer>,
   setter: UpdateStateValueFunc,
-) => void;
+) => Promise<void>;
 
 export type CheckAccountFunc = (account: AccountInfo<Buffer>) => boolean;
 

--- a/js/packages/common/src/contexts/meta/types.ts
+++ b/js/packages/common/src/contexts/meta/types.ts
@@ -83,16 +83,6 @@ export interface MetaState {
 
 export interface MetaContextState extends MetaState {
   isLoading: boolean;
-  update: (
-    auctionAddress?: any,
-    bidderAddress?: any,
-  ) => Promise<
-    [
-      ParsedAccount<AuctionData>,
-      ParsedAccount<BidderPot>,
-      ParsedAccount<BidderMetadata>,
-    ]
-  >;
   pullAuctionPage: (auctionAddress: StringPublicKey) => Promise<MetaState>;
   pullBillingPage: (auctionAddress: StringPublicKey) => void;
   pullAllMetadata: () => void;

--- a/js/packages/web/next-env.d.ts
+++ b/js/packages/web/next-env.d.ts
@@ -1,3 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/js/packages/web/src/actions/sendPlaceBid.ts
+++ b/js/packages/web/src/actions/sendPlaceBid.ts
@@ -1,4 +1,9 @@
-import { Keypair, Connection, TransactionInstruction } from '@solana/web3.js';
+import {
+  Keypair,
+  Connection,
+  TransactionInstruction,
+  Commitment,
+} from '@solana/web3.js';
 import {
   sendTransactionWithRetry,
   placeBid,
@@ -28,6 +33,7 @@ export async function sendPlaceBid(
   accountsByMint: Map<string, TokenAccount>,
   // value entered by the user adjust to decimals of the mint
   amount: number | BN,
+  commitment: Commitment = 'single',
 ) {
   const signers: Keypair[][] = [];
   const instructions: TransactionInstruction[][] = [];
@@ -42,16 +48,17 @@ export async function sendPlaceBid(
     signers,
   );
 
-  await sendTransactionWithRetry(
+  const { txid } = await sendTransactionWithRetry(
     connection,
     wallet,
     instructions[0],
     signers[0],
-    'single',
+    commitment,
   );
 
   return {
     amount: bid,
+    txid,
   };
 }
 

--- a/js/packages/web/src/components/AuctionCard/index.tsx
+++ b/js/packages/web/src/components/AuctionCard/index.tsx
@@ -22,7 +22,7 @@ import {
   useWalletModal,
   VaultState,
   BidStateType,
-  loadMultipleAccounts,
+  loadMultipleAccountsIntoMetaState,
 } from '@oyster/common';
 import { useWallet } from '@solana/wallet-adapter-react';
 import { AuctionView, useBidsForAuction, useUserBalance } from '../../hooks';
@@ -265,10 +265,9 @@ export const AuctionCard = ({
 
   const isOpenEditionSale =
     auctionView.auction.info.bidState.type === BidStateType.OpenEdition;
-
-  const isBidderPotEmpty = Boolean(auctionView.myBidderPot?.info.emptied);
   const doesInstantSaleHasNoItems =
-    isBidderPotEmpty && auctionView.auction.info.bidState.max.toNumber() === bids.length;
+    Number(auctionView.myBidderPot?.info.emptied) !== 0 &&
+    auctionView.auction.info.bidState.max.toNumber() === bids.length;
    
   const shouldHideInstantSale =
     !isOpenEditionSale &&
@@ -595,8 +594,7 @@ export const AuctionCard = ({
                 try {
                   const instantSalePrice =
                     auctionView.auctionDataExtended?.info.instantSalePrice;
-                  const winningConfigType =
-                    auctionView.items[0][0].winningConfigType;
+                  const winningConfigType = auctionView.participationItem?.winningConfigType || auctionView.items[0][0].winningConfigType;
                   const isAuctionItemMaster =
                     winningConfigType ===
                     WinningConfigType.FullRightsTransfer ||
@@ -649,7 +647,7 @@ export const AuctionCard = ({
                             continue;
                           }
 
-                          const patch = await loadMultipleAccounts(
+                          const patch = await loadMultipleAccountsIntoMetaState(
                             connection,
                             keys.map(k => k.toBase58()),
                             'confirmed',
@@ -781,6 +779,7 @@ export const AuctionCard = ({
                         value={value}
                         style={{
                           width: '100%',
+                          background: '#393939',
                           borderRadius: 16,
                         }}
                         onChange={setValue}


### PR DESCRIPTION
### Background
The instant sale action is 2 transactions. The first for placing a bid and another immediately after for redeeming it.

### Issue
Currently, in between the two transactions, the action calls the `update` function on the meta context which triggers a complete download for all site data. Users would leave the browser session after placing the bid but not redeem it. This left several users with sol placed in escrow but the NFT was not sent to the user.

  ### Resolution
  - Replace the `update` meta context function with one that patches the state given a segment of meta state. A load multiple accounts helper was introduced to query just the accounts that changed from the placing of the bid.
 - The displaying of the redeem button is adjusted to display the button in the case of a bid being placed but not redeemed.
