### PR TITLE
fix winner index value

### DIFF
--- a/js/packages/common/src/models/metaplex/index.ts
+++ b/js/packages/common/src/models/metaplex/index.ts
@@ -577,7 +577,7 @@ export class BidRedemptionTicketV2 implements BidRedemptionTicket {
     if (this.data[1] == 0) {
       this.winnerIndex = null;
     } else {
-      this.winnerIndex = new BN(this.data.slice(1, 9), 'le');
+      this.winnerIndex = new BN(this.data.slice(2, 8), 'le');
       offset += 8;
     }
 


### PR DESCRIPTION
Looks like there is a bug in computing `winnerIndex` right now. 
And because of that there is an issue in computing `bidRedemptions` for the `AuctionManager`.



Since I wasn't sure about the fix, I went ahead and found the [corresponding logic](https://github.com/metaplex-foundation/metaplex/blob/master/rust/metaplex/program/src/state.rs#L1487) in the rust codebase (and substituted with that).