### PR TITLE
Adds Tool to deploy all Metaplex contracts locally

### DIFF
--- a/rust/package.json
+++ b/rust/package.json
@@ -17,6 +17,7 @@
   },
   "scripts": {
     "idl": "node test/idlToTs",
+    "deploy-all": "node tools/deployAll.js",
     "test": "env MY_WALLET=$HOME/.config/solana/id.json ts-mocha -p ./tsconfig.json -t 1000000 test/*.ts"
   },
   "dependencies": {

--- a/rust/tools/deployAll.js
+++ b/rust/tools/deployAll.js
@@ -1,0 +1,27 @@
+import {extname, join} from 'path';
+import {readdir} from 'fs';
+import {spawn} from 'child_process';
+
+const cwd = process.cwd()
+const soPath = join(cwd, "target", "deploy")
+readdir(soPath, (err, files) => {
+  if (!!err) {
+    console.error(err)
+    process.exit(1)
+  }
+
+  const bpfBins = files.filter(f => extname(f) === ".so")
+  bpfBins.forEach((bfile) => {
+    const bin = join(soPath, bfile)
+    const proc = spawn('solana', ['deploy', bin])
+    proc.stdout.on('data', d => console.log(d.toString()))
+    proc.stderr.on('data', d => console.error(d.toString()))
+    proc.on('close', (code) => {
+      if (code !== 0) {
+        console.log(`Deployment Failed: ${bin}, exit code ${code}\n`)
+        return
+      }
+      console.log(`Deployment Complete: ${bin}\n`)
+    })
+  })
+});


### PR DESCRIPTION
This PR adds a tool to deploy all contracts to a local validator for quick and easy local rust development.
It is very helpful to have this on a loop while changing things about the contracts.