### PR TITLE
Update Metaplex CLI to support --no-mutable flag

### DIFF
--- a/js/packages/cli/src/candy-machine-cli.ts
+++ b/js/packages/cli/src/candy-machine-cli.ts
@@ -73,6 +73,7 @@ programCommand('upload')
     '(existing) AWS S3 Bucket name (required if using aws)',
   )
   .option('--no-retain-authority', 'Do not retain authority to update metadata')
+  .option('--no-mutable', 'Metadata will not be editable')
   .action(async (files: string[], options, cmd) => {
     const {
       number,
@@ -84,6 +85,7 @@ programCommand('upload')
       ipfsInfuraSecret,
       awsS3Bucket,
       retainAuthority,
+      mutable,
     } = cmd.opts();
 
     if (storage === 'ipfs' && (!ipfsInfuraProjectId || !ipfsInfuraSecret)) {
@@ -91,13 +93,15 @@ programCommand('upload')
         'IPFS selected as storage option but Infura project id or secret key were not provided.',
       );
     }
-    if (storage === 'aws' && (!awsS3Bucket)) {
+    if (storage === 'aws' && !awsS3Bucket) {
       throw new Error(
         'aws selected as storage option but existing bucket name (--aws-s3-bucket) not provided.',
       );
     }
     if (!(storage === 'arweave' || storage === 'ipfs' || storage === 'aws')) {
-      throw new Error("Storage option must either be 'arweave', 'ipfs', or 'aws'.");
+      throw new Error(
+        "Storage option must either be 'arweave', 'ipfs', or 'aws'.",
+      );
     }
     const ipfsCredentials = {
       projectId: ipfsInfuraProjectId,
@@ -140,6 +144,7 @@ programCommand('upload')
         elemCount,
         storage,
         retainAuthority,
+        mutable,
         ipfsCredentials,
         awsS3Bucket,
       );
@@ -458,6 +463,8 @@ programCommand('show')
       log.info('maxSupply: ', config.data.maxSupply.toNumber());
     //@ts-ignore
     log.info('retainAuthority: ', config.data.retainAuthority);
+    //@ts-ignore
+    log.info('isMutable: ', config.data.isMutable);
     //@ts-ignore
     log.info('maxNumberOfLines: ', config.data.maxNumberOfLines);
   });

--- a/js/packages/cli/src/commands/upload.ts
+++ b/js/packages/cli/src/commands/upload.ts
@@ -23,6 +23,7 @@ export async function upload(
   totalNFTs: number,
   storage: string,
   retainAuthority: boolean,
+  mutable: boolean,
   ipfsCredentials: ipfsCreds,
   awsS3Bucket: string,
 ): Promise<boolean> {
@@ -98,7 +99,7 @@ export async function upload(
             maxNumberOfLines: new BN(totalNFTs),
             symbol: manifest.symbol,
             sellerFeeBasisPoints: manifest.seller_fee_basis_points,
-            isMutable: true,
+            isMutable: mutable,
             maxSupply: new BN(0),
             retainAuthority: retainAuthority,
             creators: manifest.properties.creators.map(creator => {


### PR DESCRIPTION
Hello there!

After a brief discussion with Jordan(@bhgames) on twitter I came to the conclusion to add support for passing in a --no-mutable flag to the upload command.

Here is a video demonstrating how it works:

https://drive.google.com/file/d/1sGZO2OEusfnoN0sOznEtq3Q0VQKU4H7P/view?usp=sharing

CC: @adamjeffries

Edit:

Failed to mention in case you are wondering. ghoulplex was simply an alias for my fork haha. 🤣