### PR TITLE
Refactor: remove `await` operator from `anchor.InstructionFn` calls

### DIFF
--- a/js/packages/cli/src/commands/mint.ts
+++ b/js/packages/cli/src/commands/mint.ts
@@ -42,7 +42,7 @@ export async function mint(
 
   const remainingAccounts = [];
   const signers = [mint, userKeyPair];
-  const instructions = [
+  const instructions: anchor.web3.TransactionInstruction[] = [
     anchor.web3.SystemProgram.createAccount({
       fromPubkey: userKeyPair.publicKey,
       newAccountPubkey: mint.publicKey,

--- a/js/packages/cli/src/commands/mint.ts
+++ b/js/packages/cli/src/commands/mint.ts
@@ -111,7 +111,7 @@ export async function mint(
   const masterEdition = await getMasterEdition(mint.publicKey);
 
   instructions.push(
-    await anchorProgram.instruction.mintNft({
+    anchorProgram.instruction.mintNft({
       accounts: {
         config: configAddress,
         candyMachine: candyMachineAddress,

--- a/js/packages/cli/src/fair-launch-cli.ts
+++ b/js/packages/cli/src/fair-launch-cli.ts
@@ -486,7 +486,7 @@ program
     }
 
     instructions.push(
-      await anchorProgram.instruction.purchaseTicket(
+      anchorProgram.instruction.purchaseTicket(
         bump,
         new anchor.BN(amountNumber),
         {
@@ -786,7 +786,7 @@ async function adjustTicket({
   }
 
   instructions.push(
-    await anchorProgram.instruction.adjustTicket(new anchor.BN(amountNumber), {
+    anchorProgram.instruction.adjustTicket(new anchor.BN(amountNumber), {
       accounts: {
         fairLaunchTicket,
         fairLaunch,

--- a/js/packages/cli/src/fair-launch-cli.ts
+++ b/js/packages/cli/src/fair-launch-cli.ts
@@ -419,7 +419,7 @@ program
     );
 
     const remainingAccounts = [];
-    const instructions = [];
+    const instructions: anchor.web3.TransactionInstruction[] = [];
     const signers = [];
     //@ts-ignore
     const tokenAta = fairLaunchObj.treasuryMint
@@ -591,7 +591,7 @@ program
     const mintKey = new anchor.web3.PublicKey(mint);
     const dest = new anchor.web3.PublicKey(destination);
     const token = (await getAtaForMint(mintKey, dest))[0];
-    const instructions = [];
+    const instructions: anchor.web3.TransactionInstruction[] = [];
     const tokenApp = new Token(
       anchorProgram.provider.connection,
       //@ts-ignore
@@ -719,7 +719,7 @@ async function adjustTicket({
   adjustMantissa: boolean;
 }) {
   const remainingAccounts = [];
-  const instructions = [];
+  const instructions: anchor.web3.TransactionInstruction[] = [];
   const signers = [];
   //@ts-ignore
   const tokenAta = fairLaunchObj.treasuryMint
@@ -1992,7 +1992,7 @@ program
       tokenAccount,
     );
 
-    const instructions = [];
+    const instructions: anchor.web3.TransactionInstruction[] = [];
     if (!exists) {
       instructions.push(
         createAssociatedTokenAccountInstruction(

--- a/js/packages/fair-launch/src/fair-launch.ts
+++ b/js/packages/fair-launch/src/fair-launch.ts
@@ -315,7 +315,7 @@ const getSetupForTicketing = async (
   const ticket = fairLaunch.ticket;
 
   const remainingAccounts = [];
-  const instructions = [];
+  const instructions: anchor.web3.TransactionInstruction[] = [];
   const signers = [];
 
   let amountLamports = 0;

--- a/js/packages/fair-launch/src/fair-launch.ts
+++ b/js/packages/fair-launch/src/fair-launch.ts
@@ -398,7 +398,7 @@ const getSetupForTicketing = async (
     );
     if (!seq) {
       instructions.push(
-        await anchorProgram.instruction.createTicketSeq(seqBump, {
+        anchorProgram.instruction.createTicketSeq(seqBump, {
           accounts: {
             fairLaunchTicketSeqLookup,
             fairLaunch: fairLaunch.id,


### PR DESCRIPTION
`anchor.InstructionFn` is synchronous, so the `await` operator has no effect here.