### PR TITLE
Auction Status for Instant Sales

### DIFF
--- a/js/packages/web/src/components/AuctionRenderCard/hooks/useAuctionStatus.ts
+++ b/js/packages/web/src/components/AuctionRenderCard/hooks/useAuctionStatus.ts
@@ -1,0 +1,77 @@
+import { formatTokenAmount, fromLamports, useMint, PriceFloorType } from '@oyster/common';
+import { AuctionView, AuctionViewState, useBidsForAuction, useHighestBidForAuction } from '../../../hooks';
+import { BN } from 'bn.js';
+
+interface AuctionStatusLabels {
+  status: string;
+  amount: string | number;
+}
+
+export const useAuctionStatus = (
+  auctionView: AuctionView,
+): AuctionStatusLabels => {
+  const bids = useBidsForAuction(auctionView.auction.pubkey);
+  const winningBid = useHighestBidForAuction(auctionView.auction.pubkey);
+  const mintInfo = useMint(auctionView.auction.info.tokenMint);
+
+  const participationFixedPrice =
+    auctionView.auctionManager.participationConfig?.fixedPrice || 0;
+  const participationOnly = auctionView.auctionManager.numWinners.eq(new BN(0));
+  const priceFloor =
+    auctionView.auction.info.priceFloor.type === PriceFloorType.Minimum
+      ? auctionView.auction.info.priceFloor.minPrice?.toNumber() || 0
+      : 0;
+
+
+  let status = 'Starting Bid';
+  
+  let amount: string | number = fromLamports(
+    participationOnly ? participationFixedPrice : priceFloor,
+    mintInfo,
+  );
+
+  const countdown = auctionView.auction.info.timeToEnd();
+
+  let ended = countdown?.hours === 0 && countdown?.minutes === 0 && countdown?.seconds === 0;
+
+  if (auctionView.isInstantSale) {
+    const soldOut = bids.length === auctionView.items.length;
+    
+    status = auctionView.state === AuctionViewState.Ended ? 'Ended' : 'Price';
+
+    if (soldOut) {
+      status = 'Sold Out';
+    }
+
+    amount = formatTokenAmount(auctionView.auctionDataExtended?.info.instantSalePrice?.toNumber());
+
+    return {
+      status,
+      amount,
+    }
+  }
+
+  if (bids.length > 0) {
+    amount = formatTokenAmount(winningBid.info.lastBid);
+    status = 'Current Bid';
+  }
+
+  if (ended) {
+    if (bids.length === 0) {
+      return {
+        status: 'Ended',
+        amount
+      }
+    }
+
+    return {
+      status: 'Winning Bid',
+      amount
+    }
+  }
+
+  return {
+    status,
+    amount,
+  }
+};


### PR DESCRIPTION
### Goal

Auction status on the listing (ie auction) view supports instant sale without breaking status on standard auctions.

### Changes
- Migrate status computing to hook reserved for auction rendered card. The hook returns status and amount.


![Screenshot from 2021-10-13 15-22-09](https://user-images.githubusercontent.com/2388118/137221652-bc7818f4-be28-4eb7-a7ec-cd2890ed5fe5.png)
