### PR TITLE
Allow assets starting from any number

### DIFF
--- a/js/packages/cli/src/commands/upload.ts
+++ b/js/packages/cli/src/commands/upload.ts
@@ -178,11 +178,11 @@ export async function upload(
               const index = keys[i];
               return cacheContent.items[index]?.onChain || false;
             });
-            const ind = keys[indexes[0]];
+            const ind = indexes[0];
 
             if (onChain.length != indexes.length) {
               log.info(
-                `Writing indices ${ind}-${keys[indexes[indexes.length - 1]]}`,
+                `Writing indices ${ind}-${indexes[indexes.length - 1]}`,
               );
               try {
                 await anchorProgram.rpc.addConfigLines(
@@ -209,7 +209,7 @@ export async function upload(
               } catch (e) {
                 log.error(
                   `saving config line ${ind}-${
-                    keys[indexes[indexes.length - 1]]
+                    indexes[indexes.length - 1]
                   } failed`,
                   e,
                 );


### PR DESCRIPTION
This change removes the need for asset and metadata files to start with 0 (zero). So instead of having:

```
0.png
0.json
1.png
1.json
2.png
2.json
```

...I can start with 1 (or any number, FWIW) like this:

```
1.png
1.json
2.png
2.json
3.png
3.json
```

This also allows me to generate, say, 100 files names 1.png to 100.png, then split them in different directories, then upload them with one cache file per directory, and then generate one candy machine per directory and cache file. All using different groups of assets from the same generated collection. Before this change, I would've needed to rename all the files and edit all the json metadata after generating them so that each group starts with 0.