### PR TITLE
GIF support for Candy Machine

### DIFF
--- a/js/packages/cli/src/commands/verifyTokenMetadata/__tests__/verifyTokenMetadata.ts
+++ b/js/packages/cli/src/commands/verifyTokenMetadata/__tests__/verifyTokenMetadata.ts
@@ -21,11 +21,12 @@ describe('`metaplex verify_token_metadata`', () => {
   });
 
   it('catches mismatched assets', () => {
+    const imageType = 'png';
     const mismatchedAssets = getFiles(
       path.join(__dirname, '../__fixtures__/mismatchedAssets'),
     );
     expect(() =>
-      verifyTokenMetadata({ files: mismatchedAssets }),
+      verifyTokenMetadata({ files: mismatchedAssets, imageType }),
     ).toThrowErrorMatchingInlineSnapshot(
       `"number of png files (0) is different than the number of json files (1)"`,
     );
@@ -39,6 +40,7 @@ describe('`metaplex verify_token_metadata`', () => {
       expect(() =>
         verifyTokenMetadata({
           files: [invalidSchema, invalidSchema.replace('.json', '.png')],
+          imageType: 'png',
         }),
       ).toThrowErrorMatchingSnapshot();
     });
@@ -74,6 +76,7 @@ describe('`metaplex verify_token_metadata`', () => {
   it('warns when using different image URIs', () => {
     verifyImageURL(
       'https://google.com?ext=png',
+      'png',
       [{ uri: 'https://google.com?ext=png', type: 'image/png' }],
       '0.json',
     );

--- a/js/packages/cli/src/helpers/upload/arweave.ts
+++ b/js/packages/cli/src/helpers/upload/arweave.ts
@@ -6,8 +6,8 @@ import fetch from 'node-fetch';
 import { ARWEAVE_PAYMENT_WALLET } from '../constants';
 import { sendTransactionWithRetryWithKeypair } from '../transactions';
 
-async function upload(data: FormData, manifest, index) {
-  log.debug(`trying to upload ${index}.png: ${manifest.name}`);
+async function upload(data: FormData, manifest, imageType, index) {
+  log.debug(`trying to upload ${index}.${imageType}: ${manifest.name}`);
   return await (
     await fetch(
       'https://us-central1-principal-lane-200702.cloudfunctions.net/uploadFile4',
@@ -25,6 +25,7 @@ export async function arweaveUpload(
   anchorProgram,
   env,
   image,
+  imageType,
   manifestBuffer,
   manifest,
   index,
@@ -52,12 +53,12 @@ export async function arweaveUpload(
   data.append('transaction', tx['txid']);
   data.append('env', env);
   data.append('file[]', fs.createReadStream(image), {
-    filename: `image.png`,
-    contentType: 'image/png',
+    filename: `image.${imageType}`,
+    contentType: `image/${imageType}`,
   });
   data.append('file[]', manifestBuffer, 'metadata.json');
 
-  const result = await upload(data, manifest, index);
+  const result = await upload(data, manifest, imageType, index);
 
   const metadataFile = result.messages?.find(
     m => m.filename === 'manifest.json',

--- a/js/packages/cli/src/helpers/upload/aws.ts
+++ b/js/packages/cli/src/helpers/upload/aws.ts
@@ -34,6 +34,7 @@ async function uploadFile(
 export async function awsUpload(
   awsS3Bucket: string,
   file: string,
+  fileType: string,
   manifestBuffer: Buffer,
 ) {
   const REGION = 'us-east-1'; // TODO: Parameterize this.
@@ -47,7 +48,7 @@ export async function awsUpload(
     s3Client,
     awsS3Bucket,
     filename,
-    'image/png',
+    `image/${fileType}`,
     fileStream,
   );
 
@@ -59,7 +60,8 @@ export async function awsUpload(
   });
   const updatedManifestBuffer = Buffer.from(JSON.stringify(manifestJson));
 
-  const metadataFilename = filename.replace(/.png$/, '.json');
+  const fileTypeRegex = new RegExp(`.${fileType}`);
+  const metadataFilename = filename.replace(fileTypeRegex, '.json');
   const metadataUrl = await uploadFile(
     s3Client,
     awsS3Bucket,


### PR DESCRIPTION
  Add support to upload/verify gif images. It fixes #511

   - Update the upload command to accept --image-type gif|png (default: png)
   - Update the verify_token_metadata command to accept --image-type gif|png (default: png)
   - Update arweave and aws uploaders to accept gif
   
   
   Command example using gif images:
   
   ```bash
   metaplex upload ~/nfts/gifs --image-type gif --keypair ~/.config/solana/id.json
   metaplex verify_token_metadata ~/nfts/gifs --image-type gif --keypair ~/.config/solana/id.json
   ```
   
   If you don't add the image-type argument, it will use png, the same behavior before this PR. 
   