### PR TITLE
reset alert state after upload success

### DIFF
--- a/js/packages/web/src/views/artCreate/index.tsx
+++ b/js/packages/web/src/views/artCreate/index.tsx
@@ -128,6 +128,7 @@ export const ArtCreateView = () => {
       );
 
       if (_nft) setNft(_nft);
+      setAlertMessage('');
     } catch (e: any) {
       setAlertMessage(e.message);
     } finally {


### PR DESCRIPTION
#### What is wrong?

After a failed upload, the UI would continue to report failed uploads, even if they succeeded unless you hard refreshed your browser.

#### How did I test this fix?

I set up a test upload api for devnet and configured this project to use the upload api. I forced uploads to fail, then manually created an NFT to see it fail. I then allowed uploads to succeed and retested to confirm that the success message now displays.