### PR TITLE
fix first load when zero auctions

### DIFF
--- a/js/packages/web/src/hooks/useAuctions.ts
+++ b/js/packages/web/src/hooks/useAuctions.ts
@@ -70,7 +70,7 @@ export function useStoreAuctionsList() {
   const result = useMemo(() => {
     return Object.values(auctionManagersByAuction).map(
       manager => auctions[manager.info.auction],
-    );
+    ).filter(Boolean);
   }, [Object.keys(auctions).length, auctionManagersByAuction]);
   return result;
 }


### PR DESCRIPTION
When first using the project and there are no auctions, after connecting a wallet, the UI would go completely black.

This was caused by `undefined` left in the auction list and began after the recent large UI upgrade.

This PR filters out falsey values which will not render.