### PR TITLE
Fix float and integer check for metaplex share allocation

### DIFF
--- a/js/packages/cli/src/commands/verifyTokenMetadata/__tests__/verifyTokenMetadata.ts
+++ b/js/packages/cli/src/commands/verifyTokenMetadata/__tests__/verifyTokenMetadata.ts
@@ -60,6 +60,24 @@ describe('`metaplex verify_token_metadata`', () => {
           { address: 'some-solana-address', share: 80 },
           {
             address: 'some-other-solana-address',
+            share: 19,
+          },
+        ],
+
+        'placeholder-manifest-file',
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Creator share for placeholder-manifest-file does not add up to 100, got: 99."`,
+    );
+  });
+
+  it('throws on invalid share number type', () => {
+    expect(() =>
+      verifyAggregateShare(
+        [
+          { address: 'some-solana-address', share: 80 },
+          {
+            address: 'some-other-solana-address',
             share: 19.9,
           },
         ],
@@ -67,7 +85,7 @@ describe('`metaplex verify_token_metadata`', () => {
         'placeholder-manifest-file',
       ),
     ).toThrowErrorMatchingInlineSnapshot(
-      `"Creator share for placeholder-manifest-file does not add up to 100, got: 99.9."`,
+      `"Creator share for placeholder-manifest-file contains floats. Only use integers for this number."`,
     );
   });
 

--- a/js/packages/cli/src/commands/verifyTokenMetadata/index.ts
+++ b/js/packages/cli/src/commands/verifyTokenMetadata/index.ts
@@ -46,6 +46,11 @@ export const verifyAggregateShare = (
   const aggregateShare = creators
     .map(creator => creator.share)
     .reduce((memo, share) => {
+      if (!Number.isInteger(share)) {
+        throw new Error(
+          `Creator share for ${manifestFile} contains floats. Only use integers for this number.`,
+        );
+      }
       return memo + share;
     }, 0);
   // Check that creator share adds up to 100
@@ -90,7 +95,7 @@ export const verifyImageURL = (image, files, manifestFile) => {
     // We _could_ match against this in the JSON schema validation, but it is totally valid to have arbitrary URLs to images here.
     // The downside, though, is that those images will not get uploaded to Arweave since they're not on-disk.
     log.warn(`We expected the \`image\` property in ${manifestFile} to be ${expectedImagePath}.
-This will still work properly (assuming the URL is valid!), however, this image will not get uploaded to Arweave through the \`metaplex upload\` command.   
+This will still work properly (assuming the URL is valid!), however, this image will not get uploaded to Arweave through the \`metaplex upload\` command.
 If you want us to take care of getting this into Arweave, make sure to set \`image\`: "${expectedImagePath}"
 The \`metaplex upload\` command will automatically substitute this URL with the Arweave URL location.
     `);


### PR DESCRIPTION
# Our 4000$ honest mistake

Yesterday we used the Fair Launch Protocol for the first time to launch our collection (I'm a developer on several other projects, but they didn't use the FLP). And it did go well up until we got to mint.

We got the error where it says that the creators shares must equal 100 for the metadata to be valid and that no one will be able to mint.

It's tough ! Because it was the first time we used multiple wallets and had to split the costs (and we had to change it last minute).

It looked like this :

```json
"creators":[
    {"address":"_redacted_", "share":16.5},
    {"address":"_redacted_", "share":16.5},
    {"address":"_redacted_", "share":16.5},
    {"address":"_redacted_", "share":50.5}
]
```

The problem was that the `verify_token_metadata` returned no error when there actually was one. When we checked the rust code, we realised that the share number had to be of `u8` type. No floaties allowed in there !

This PR is fixing this by throwing an error when the numbers in `creators[].share` are not integers. I hope this will help someone avoid this mistake in the future.