### PR TITLE
[Feature] ability to mint multiple tokens at once

### DIFF
--- a/js/packages/cli/README.md
+++ b/js/packages/cli/README.md
@@ -230,6 +230,13 @@ metaplex mint_one_token -k ~/.config/solana/id.json
 ts-node cli mint_one_token -k ~/.config/solana/id.json
 ```
 
+6. Test mint multiple tokens 
+
+```
+metaplex mint_multiple_tokens -k ~/.config/solana/id.json -n 100
+ts-node cli mint_multiple_tokens -k ~/.config/solana/id.json -n 100
+```
+
 6. Check if you received any tokens.
 
 ```

--- a/js/packages/cli/src/candy-machine-cli.ts
+++ b/js/packages/cli/src/candy-machine-cli.ts
@@ -846,6 +846,32 @@ programCommand('mint_tokens')
     log.info(`minted ${parsedNumber} tokens`);
   });
 
+programCommand('mint_multiple_tokens')
+  .option('-n, --number <string>', 'Number of tokens')
+  .action(async (directory, cmd) => {
+    const { keypair, env, cacheName, number } = cmd.opts();
+
+    const NUMBER_OF_NFTS_TO_MINT = parseInt(number, 10);
+    const cacheContent = loadCache(cacheName, env);
+    const configAddress = new PublicKey(cacheContent.program.config);
+
+    log.info(`Minting ${NUMBER_OF_NFTS_TO_MINT} tokens...`);
+
+    const mintToken = async index => {
+      const tx = await mint(keypair, env, configAddress);
+      log.info(`transaction ${index} complete`, tx);
+
+      if (index < NUMBER_OF_NFTS_TO_MINT - 1) {
+        log.info('minting another token...');
+        await mintToken(index + 1);
+      }
+    };
+
+    await mintToken(0);
+
+    log.info('mint_multiple_tokens finished');
+  });
+
 programCommand('sign')
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   .option('-m, --metadata <string>', 'base58 metadata account id')

--- a/js/packages/cli/src/candy-machine-cli.ts
+++ b/js/packages/cli/src/candy-machine-cli.ts
@@ -823,33 +823,14 @@ programCommand('mint_one_token')
     log.info('mint_one_token finished', tx);
   });
 
-programCommand('mint_tokens')
-  .option('-n, --number <number>', 'Number of tokens to mint', '1')
-  .action(async (directory, cmd) => {
-    const { keypair, env, cacheName, number, rpcUrl } = cmd.opts();
-
-    const parsedNumber = parseInt(number);
-
-    const cacheContent = loadCache(cacheName, env);
-    const configAddress = new PublicKey(cacheContent.program.config);
-    for (let i = 0; i < parsedNumber; i++) {
-      await mint(
-        keypair,
-        env,
-        configAddress,
-        cacheContent.program.uuid,
-        rpcUrl,
-      );
-      log.info(`token ${i} minted`);
-    }
-
-    log.info(`minted ${parsedNumber} tokens`);
-  });
-
 programCommand('mint_multiple_tokens')
   .option('-n, --number <string>', 'Number of tokens')
-  .action(async (directory, cmd) => {
-    const { keypair, env, cacheName, number } = cmd.opts();
+  .option(
+    '-r, --rpc-url <string>',
+    'custom rpc url since this is a heavy command',
+  )
+  .action(async (_, cmd) => {
+    const { keypair, env, cacheName, number, rpcUrl } = cmd.opts();
 
     const NUMBER_OF_NFTS_TO_MINT = parseInt(number, 10);
     const cacheContent = loadCache(cacheName, env);
@@ -858,8 +839,14 @@ programCommand('mint_multiple_tokens')
     log.info(`Minting ${NUMBER_OF_NFTS_TO_MINT} tokens...`);
 
     const mintToken = async index => {
-      const tx = await mint(keypair, env, configAddress);
-      log.info(`transaction ${index} complete`, tx);
+      const tx = await mint(
+        keypair,
+        env,
+        configAddress,
+        cacheContent.program.uuid,
+        rpcUrl,
+      );
+      log.info(`transaction ${index + 1} complete`, tx);
 
       if (index < NUMBER_OF_NFTS_TO_MINT - 1) {
         log.info('minting another token...');
@@ -869,6 +856,7 @@ programCommand('mint_multiple_tokens')
 
     await mintToken(0);
 
+    log.info(`minted ${NUMBER_OF_NFTS_TO_MINT} tokens`);
     log.info('mint_multiple_tokens finished');
   });
 


### PR DESCRIPTION
Implemented a feature to mint a `---number` of tokens instead of just one. 

README is updated:

```
metaplex mint_multiple_tokens -k ~/.config/solana/id.json -n 100
ts-node cli mint_multiple_tokens -k ~/.config/solana/id.json -n 100
```

Proof of functionality:
<img width="1245" alt="Screen Shot 2021-10-26 at 5 34 06 PM" src="https://user-images.githubusercontent.com/3037893/138980903-ed4a80a8-00fd-4712-8b01-bed1ed1162ab.png">


