### PR TITLE
add custom rpc url option for candy machine cli

### DIFF
--- a/js/packages/cli/src/candy-machine-cli.ts
+++ b/js/packages/cli/src/candy-machine-cli.ts
@@ -192,11 +192,11 @@ programCommand('verify_token_metadata')
   });
 
 programCommand('verify').action(async (directory, cmd) => {
-  const { env, keypair, cacheName } = cmd.opts();
+  const { env, rpcUrl, keypair, cacheName } = cmd.opts();
 
   const cacheContent = loadCache(cacheName, env);
   const walletKeyPair = loadWalletKey(keypair);
-  const anchorProgram = await loadCandyProgram(walletKeyPair, env);
+  const anchorProgram = await loadCandyProgram(walletKeyPair, env, rpcUrl);
 
   const configAddress = new PublicKey(cacheContent.program.config);
   const config = await anchorProgram.provider.connection.getAccountInfo(
@@ -351,7 +351,7 @@ programCommand('verify_price')
   .option('-p, --price <string>')
   .option('--cache-path <string>')
   .action(async (directory, cmd) => {
-    const { keypair, env, price, cacheName, cachePath } = cmd.opts();
+    const { keypair, env, rpcUrl, price, cacheName, cachePath } = cmd.opts();
     const lamports = parsePrice(price);
 
     if (isNaN(lamports)) {
@@ -369,7 +369,7 @@ programCommand('verify_price')
     }
 
     const walletKeyPair = loadWalletKey(keypair);
-    const anchorProgram = await loadCandyProgram(walletKeyPair, env);
+    const anchorProgram = await loadCandyProgram(walletKeyPair, env, rpcUrl);
 
     const candyAddress = new PublicKey(cacheContent.candyMachineAddress);
 
@@ -392,7 +392,7 @@ programCommand('verify_price')
 programCommand('show')
   .option('--cache-path <string>')
   .action(async (directory, cmd) => {
-    const { keypair, env, cacheName, cachePath } = cmd.opts();
+    const { keypair, env, rpcUrl, cacheName, cachePath } = cmd.opts();
 
     const cacheContent = loadCache(cacheName, env, cachePath);
 
@@ -403,7 +403,7 @@ programCommand('show')
     }
 
     const walletKeyPair = loadWalletKey(keypair);
-    const anchorProgram = await loadCandyProgram(walletKeyPair, env);
+    const anchorProgram = await loadCandyProgram(walletKeyPair, env, rpcUrl);
 
     const [candyMachine] = await getCandyMachineAddress(
       new PublicKey(cacheContent.program.config),
@@ -494,6 +494,7 @@ programCommand('create_candy_machine')
     const {
       keypair,
       env,
+      rpcUrl,
       price,
       cacheName,
       splToken,
@@ -505,7 +506,7 @@ programCommand('create_candy_machine')
     const cacheContent = loadCache(cacheName, env);
 
     const walletKeyPair = loadWalletKey(keypair);
-    const anchorProgram = await loadCandyProgram(walletKeyPair, env);
+    const anchorProgram = await loadCandyProgram(walletKeyPair, env, rpcUrl);
 
     let wallet = walletKeyPair.publicKey;
     const remainingAccounts = [];
@@ -603,14 +604,14 @@ programCommand('update_candy_machine')
   )
   .option('-p, --price <string>', 'SOL price')
   .action(async (directory, cmd) => {
-    const { keypair, env, date, price, cacheName } = cmd.opts();
+    const { keypair, env, rpcUrl, date, price, cacheName } = cmd.opts();
     const cacheContent = loadCache(cacheName, env);
 
     const secondsSinceEpoch = date ? parseDate(date) : null;
     const lamports = price ? parsePrice(price) : null;
 
     const walletKeyPair = loadWalletKey(keypair);
-    const anchorProgram = await loadCandyProgram(walletKeyPair, env);
+    const anchorProgram = await loadCandyProgram(walletKeyPair, env, rpcUrl);
 
     const candyMachine = new PublicKey(cacheContent.candyMachineAddress);
     const tx = await anchorProgram.rpc.updateCandyMachine(
@@ -658,10 +659,10 @@ programCommand('sign_all')
   .option('-b, --batch-size <string>', 'Batch size', '10')
   .option('-d, --daemon', 'Run signing continuously', false)
   .action(async (directory, cmd) => {
-    const { keypair, env, cacheName, batchSize, daemon } = cmd.opts();
+    const { keypair, env, rpcUrl, cacheName, batchSize, daemon } = cmd.opts();
     const cacheContent = loadCache(cacheName, env);
     const walletKeyPair = loadWalletKey(keypair);
-    const anchorProgram = await loadCandyProgram(walletKeyPair, env);
+    const anchorProgram = await loadCandyProgram(walletKeyPair, env, rpcUrl);
     const candyAddress = cacheContent.candyMachineAddress;
 
     const batchSizeParsed = parseInt(batchSize);
@@ -739,6 +740,11 @@ function programCommand(name: string) {
       '-e, --env <string>',
       'Solana cluster env name',
       'devnet', //mainnet-beta, testnet, devnet
+    )
+    .option(
+      '-r, --rpc-url <string>',
+      'RPC endpoint URL',
+      'https://api.devnet.solana.com',
     )
     .option(
       '-k, --keypair <path>',

--- a/js/packages/cli/src/helpers/accounts.ts
+++ b/js/packages/cli/src/helpers/accounts.ts
@@ -278,9 +278,16 @@ export function loadWalletKey(keypair): Keypair {
   return loaded;
 }
 
-export async function loadCandyProgram(walletKeyPair: Keypair, env: string) {
+export async function loadCandyProgram(
+  walletKeyPair: Keypair,
+  env: string,
+  customRpcUrl?: string,
+) {
   // @ts-ignore
-  const solConnection = new web3.Connection(web3.clusterApiUrl(env));
+  const solConnection = new anchor.web3.Connection(
+    //@ts-ignore
+    customRpcUrl || web3.clusterApiUrl(env),
+  );
   const walletWrapper = new anchor.Wallet(walletKeyPair);
   const provider = new anchor.Provider(solConnection, walletWrapper, {
     preflightCommitment: 'recent',


### PR DESCRIPTION
Many people from the Metaplex Discord seem to have issues with various candy_machine_cli commands using public RPCs during times of high load. This is an exploratory PR to see if this feature would be merged. 

I can do more testing if this seems like a reasonable feature to add.