### PR TITLE
Upgrade authority fixes

### DIFF
--- a/rust/token-metadata/program/src/processor.rs
+++ b/rust/token-metadata/program/src/processor.rs
@@ -195,6 +195,7 @@ pub fn process_update_metadata_accounts(
                 &metadata,
                 false,
                 update_authority_info.is_signer,
+                true
             )?;
             metadata.data = data;
         } else {


### PR DESCRIPTION
This update fixes an issue with updating metadata if the update authority is not in the creators array.
It also accomplishes a change where the metadata program token holder can create metadata for tokens that don't have it to support the wormhole