### PR TITLE
refactor: use hook on auctions list

### DIFF
--- a/js/packages/web/src/styles/app.less
+++ b/js/packages/web/src/styles/app.less
@@ -280,3 +280,34 @@ model-viewer {
     padding: 15px;
   }
 }
+
+.my-masonry-grid {
+  display: flex;
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+  margin-left: -32px !important;
+}
+
+.my-masonry-grid_column {
+  padding-left: 32px !important; /* gutter size */
+  background-clip: padding-box;
+}
+
+.my-masonry-grid_column > div {
+  /* change div to reference your elements you put in <Masonry> */
+  margin-bottom: 30px;
+}
+
+/* Optional, different gutter size on mobile */
+@media (max-width: 800px) {
+  .my-masonry-grid {
+    margin-left: -15px; /* gutter size offset */
+  }
+  .my-masonry-grid_column {
+    padding-left: 15px; /* gutter size offset */
+  }
+  .my-masonry-grid_column > div {
+    margin-bottom: 15px; /* space between items */
+  }
+}

--- a/js/packages/web/src/views/home/auctionList.tsx
+++ b/js/packages/web/src/views/home/auctionList.tsx
@@ -1,20 +1,18 @@
 import { useWallet } from '@solana/wallet-adapter-react';
 import { Col, Layout, Row, Tabs } from 'antd';
-import BN from 'bn.js';
-import React, { useState, useMemo } from 'react';
+import React, { useState } from 'react';
 import Masonry from 'react-masonry-css';
+import { Link } from 'react-router-dom';
+
+import { useMeta } from '../../contexts';
+import { AuctionRenderCard } from '../../components/AuctionRenderCard';
+import { CardLoader } from '../../components/MyLoader';
+import { Banner } from '../../components/Banner';
 import { HowToBuyModal } from '../../components/HowToBuyModal';
 
-import { AuctionViewState, useAuctions, AuctionView } from '../../hooks';
-
-import { AuctionRenderCard } from '../../components/AuctionRenderCard';
-import { Link } from 'react-router-dom';
-import { CardLoader } from '../../components/MyLoader';
-import { useMeta } from '../../contexts';
-import { Banner } from '../../components/Banner';
+import { useAuctionsList } from './hooks/useAuctionsList';
 
 const { TabPane } = Tabs;
-
 const { Content } = Layout;
 
 export enum LiveAuctionViewState {
@@ -24,128 +22,27 @@ export enum LiveAuctionViewState {
   Resale = '3',
 }
 
+const breakpointColumnsObj = {
+  default: 4,
+  1100: 3,
+  700: 2,
+  500: 1,
+};
+
 export const AuctionListView = () => {
-  const auctions = useAuctions(AuctionViewState.Live);
-  const auctionsEnded = [
-    ...useAuctions(AuctionViewState.Ended),
-    ...useAuctions(AuctionViewState.BuyNow),
-  ];
   const [activeKey, setActiveKey] = useState(LiveAuctionViewState.All);
   const { isLoading } = useMeta();
-  const { connected, publicKey } = useWallet();
-  const breakpointColumnsObj = {
-    default: 4,
-    1100: 3,
-    700: 2,
-    500: 1,
-  };
-
-  // Check if the auction is primary sale or not
-  const checkPrimarySale = (auc: AuctionView) => {
-    var flag = 0;
-    auc.items.forEach(i => {
-      i.forEach(j => {
-        if (j.metadata.info.primarySaleHappened == true) {
-          flag = 1;
-          return true;
-        }
-      });
-      if (flag == 1) return true;
-    });
-    if (flag == 1) return true;
-    else return false;
-  };
-
-  const resaleAuctions = auctions
-    .sort(
-      (a, b) =>
-        a.auction.info.endedAt
-          ?.sub(b.auction.info.endedAt || new BN(0))
-          .toNumber() || 0,
-    )
-    .filter(m => checkPrimarySale(m) == true);
-
-  // Removed resales from live auctions
-  const liveAuctions = auctions
-    .sort(
-      (a, b) =>
-        a.auction.info.endedAt
-          ?.sub(b.auction.info.endedAt || new BN(0))
-          .toNumber() || 0,
-    )
-    .filter(a => !resaleAuctions.includes(a));
-
-  const asStr = publicKey?.toBase58();
-  const participated = useMemo(
-    () =>
-      liveAuctions
-        .concat(auctionsEnded)
-        .filter((m, idx) =>
-          m.auction.info.bidState.bids.find(b => b.key == asStr),
-        ),
-    [publicKey, auctionsEnded.length],
-  );
-  let items = liveAuctions;
-  switch (activeKey) {
-    case LiveAuctionViewState.All:
-      items = liveAuctions;
-      break;
-    case LiveAuctionViewState.Participated:
-      items = participated;
-      break;
-    case LiveAuctionViewState.Resale:
-      items = resaleAuctions;
-      break;
-    case LiveAuctionViewState.Ended:
-      items = auctionsEnded;
-      break;
-  }
-
-  const liveAuctionsView = (
-    <Masonry
-      breakpointCols={breakpointColumnsObj}
-      className="my-masonry-grid"
-      columnClassName="my-masonry-grid_column"
-    >
-      {!isLoading
-        ? items.map((m, idx) => {
-            const id = m.auction.pubkey;
-            return (
-              <Link to={`/auction/${id}`} key={idx}>
-                <AuctionRenderCard key={id} auctionView={m} />
-              </Link>
-            );
-          })
-        : [...Array(10)].map((_, idx) => <CardLoader key={idx} />)}
-    </Masonry>
-  );
-  const endedAuctions = (
-    <Masonry
-      breakpointCols={breakpointColumnsObj}
-      className="my-masonry-grid"
-      columnClassName="my-masonry-grid_column"
-    >
-      {!isLoading
-        ? auctionsEnded.map((m, idx) => {
-            const id = m.auction.pubkey;
-            return (
-              <Link to={`/auction/${id}`} key={idx}>
-                <AuctionRenderCard key={id} auctionView={m} />
-              </Link>
-            );
-          })
-        : [...Array(10)].map((_, idx) => <CardLoader key={idx} />)}
-    </Masonry>
-  );
+  const { connected } = useWallet();
+  const { auctions, hasResaleAuctions } = useAuctionsList(activeKey);
 
   return (
     <>
       <Banner
-        src={'/main-banner.svg'}
-        headingText={'The amazing world of Metaplex.'}
-        subHeadingText={'Buy exclusive Metaplex NFTs.'}
+        src="/main-banner.svg"
+        headingText="The amazing world of Metaplex."
+        subHeadingText="Buy exclusive Metaplex NFTs."
         actionComponent={<HowToBuyModal buttonClassName="secondary-btn" />}
-        useBannerBg={true}
+        useBannerBg
       />
       <Layout>
         <Content style={{ display: 'flex', flexWrap: 'wrap' }}>
@@ -158,33 +55,44 @@ export const AuctionListView = () => {
                 <TabPane
                   tab={
                     <>
-                      <span className={'live'}></span> Live
+                      <span className="live"></span> Live
                     </>
                   }
                   key={LiveAuctionViewState.All}
-                >
-                  {liveAuctionsView}
-                </TabPane>
-                {resaleAuctions.length > 0 && (
+                ></TabPane>
+                {hasResaleAuctions && (
                   <TabPane
-                    tab={'Secondary Marketplace'}
+                    tab="Secondary Marketplace"
                     key={LiveAuctionViewState.Resale}
-                  >
-                    {liveAuctionsView}
-                  </TabPane>
+                  ></TabPane>
                 )}
-                <TabPane tab={'Ended'} key={LiveAuctionViewState.Ended}>
-                  {endedAuctions}
-                </TabPane>
+                <TabPane tab="Ended" key={LiveAuctionViewState.Ended}></TabPane>
                 {connected && (
                   <TabPane
-                    tab={'Participated'}
+                    tab="Participated"
                     key={LiveAuctionViewState.Participated}
-                  >
-                    {liveAuctionsView}
-                  </TabPane>
+                  ></TabPane>
                 )}
               </Tabs>
+            </Row>
+            <Row>
+              <Masonry
+                breakpointCols={breakpointColumnsObj}
+                className="masonry-grid"
+                columnClassName="masonry-grid_column"
+              >
+                {isLoading &&
+                  [...Array(10)].map((_, idx) => <CardLoader key={idx} />)}
+                {!isLoading &&
+                  auctions.map((m, idx) => (
+                    <Link to={`/auction/${m.auction.pubkey}`} key={idx}>
+                      <AuctionRenderCard
+                        key={m.auction.pubkey}
+                        auctionView={m}
+                      />
+                    </Link>
+                  ))}
+              </Masonry>
             </Row>
           </Col>
         </Content>

--- a/js/packages/web/src/views/home/hooks/useAuctionsList/index.ts
+++ b/js/packages/web/src/views/home/hooks/useAuctionsList/index.ts
@@ -1,0 +1,32 @@
+import { useMemo } from 'react';
+import { useWallet } from '@solana/wallet-adapter-react';
+
+import { useAuctions, AuctionView } from '../../../../hooks';
+
+import { LiveAuctionViewState } from '../../auctionList';
+import {
+  getFilterFunction,
+  resaleAuctionsFilter,
+  sortAuctionsByDate,
+} from './utils';
+
+export const useAuctionsList = (
+  activeKey: LiveAuctionViewState,
+): { auctions: AuctionView[]; hasResaleAuctions: boolean } => {
+  const { publicKey } = useWallet();
+  const auctions = useAuctions();
+
+  const filteredAuctions = useMemo(() => {
+    const filterFn = getFilterFunction(activeKey);
+
+    return sortAuctionsByDate(auctions).filter(auction =>
+      filterFn(auction, publicKey),
+    );
+  }, [activeKey, auctions, publicKey]);
+
+  const hasResaleAuctions = useMemo(() => {
+    return auctions.some(auction => resaleAuctionsFilter(auction));
+  }, [auctions]);
+
+  return { auctions: filteredAuctions, hasResaleAuctions };
+};

--- a/js/packages/web/src/views/home/hooks/useAuctionsList/utils.ts
+++ b/js/packages/web/src/views/home/hooks/useAuctionsList/utils.ts
@@ -1,0 +1,55 @@
+import BN from 'bn.js';
+import { PublicKey } from '@solana/web3.js';
+
+import { AuctionViewState, AuctionView } from '../../../../hooks';
+
+import { LiveAuctionViewState } from '../../auctionList';
+
+// Check if the auction is primary sale or not
+const checkPrimarySale = (auction: AuctionView): boolean =>
+  auction.items.some(item =>
+    item.some(({ metadata }) => metadata.info.primarySaleHappened),
+  );
+
+export const sortAuctionsByDate = (auctions: AuctionView[]): AuctionView[] =>
+  auctions.sort(
+    (a, b) =>
+      a.auction.info.endedAt
+        ?.sub(b.auction.info.endedAt || new BN(0))
+        .toNumber() || 0,
+  );
+
+// Removed resales from live auctions
+const liveAuctionsFilter = (auction: AuctionView): boolean =>
+  auction.state === AuctionViewState.Live && !checkPrimarySale(auction);
+
+const participatedAuctionsFilter = (
+  auction: AuctionView,
+  bidderPublicKey?: PublicKey | null,
+): boolean =>
+  auction.state !== AuctionViewState.Defective &&
+  auction.auction.info.bidState.bids.some(
+    b => b.key == bidderPublicKey?.toBase58(),
+  );
+
+export const resaleAuctionsFilter = (auction: AuctionView): boolean =>
+  auction.state === AuctionViewState.Live && checkPrimarySale(auction);
+
+const endedAuctionsFilter = ({ state }: AuctionView): boolean =>
+  [AuctionViewState.Ended, AuctionViewState.BuyNow].includes(state);
+
+export const getFilterFunction = (
+  activeKey: LiveAuctionViewState,
+): ((auction: AuctionView, bidderPublicKey?: PublicKey | null) => boolean) => {
+  switch (activeKey) {
+    case LiveAuctionViewState.All:
+      return liveAuctionsFilter;
+    case LiveAuctionViewState.Participated:
+      return participatedAuctionsFilter;
+    case LiveAuctionViewState.Resale:
+      return resaleAuctionsFilter;
+      break;
+    case LiveAuctionViewState.Ended:
+      return endedAuctionsFilter;
+  }
+};

--- a/js/packages/web/src/views/home/index.less
+++ b/js/packages/web/src/views/home/index.less
@@ -29,38 +29,40 @@ a:active {
   color: #b480eb;
 }
 
-.my-masonry-grid {
-  display: -webkit-box; /* Not needed if autoprefixing */
-  display: -ms-flexbox; /* Not needed if autoprefixing */
+.masonry-grid {
   display: flex;
-  width: auto;
+  width: 100%;
   margin-left: auto;
   margin-right: auto;
   margin-left: -32px !important;
 }
 
-.my-masonry-grid_column {
+.masonry-grid_column {
   padding-left: 32px !important; /* gutter size */
   background-clip: padding-box;
 }
 
-.my-masonry-grid_column > div {
+.masonry-grid_column > div {
   /* change div to reference your elements you put in <Masonry> */
   margin-bottom: 30px;
 }
 .ant-tabs-ink-bar {
   display: none;
 }
-.ant-tabs-top > .ant-tabs-nav::before, .ant-tabs-top > div > .ant-tabs-nav::before {
-    display: none;
+.ant-tabs-top > .ant-tabs-nav::before,
+.ant-tabs-top > div > .ant-tabs-nav::before {
+  display: none;
 }
-.ant-tabs-top > .ant-tabs-nav, .ant-tabs-bottom > .ant-tabs-nav, .ant-tabs-top > div > .ant-tabs-nav, .ant-tabs-bottom > div > .ant-tabs-nav {
+.ant-tabs-top > .ant-tabs-nav,
+.ant-tabs-bottom > .ant-tabs-nav,
+.ant-tabs-top > div > .ant-tabs-nav,
+.ant-tabs-bottom > div > .ant-tabs-nav {
   margin-bottom: 24px;
 }
 .ant-tabs-tab + .ant-tabs-tab {
   margin-left: 8px;
 }
-.ant-tabs-tab{
+.ant-tabs-tab {
   /* Auto Layout */
   display: flex;
   flex-direction: row;
@@ -72,7 +74,7 @@ a:active {
   font-weight: 600;
   height: 40px;
   opacity: 0.8;
-  &.ant-tabs-tab-active{
+  &.ant-tabs-tab-active {
     background: rgba(255, 255, 255, 0.1);
     box-shadow: 0 0 24px rgba(26, 26, 26, 0.12);
     border-radius: 8px;
@@ -100,21 +102,19 @@ a:active {
     flex: none;
     order: 0;
     flex-grow: 0;
-    margin-right:12px;
-
+    margin-right: 12px;
   }
-
 }
 
 /* Optional, different gutter size on mobile */
 @media (max-width: 800px) {
-  .my-masonry-grid {
+  .masonry-grid {
     margin-left: -15px; /* gutter size offset */
   }
-  .my-masonry-grid_column {
+  .masonry-grid_column {
     padding-left: 15px; /* gutter size offset */
   }
-  .my-masonry-grid_column > div {
+  .masonry-grid_column > div {
     margin-bottom: 15px; /* space between items */
   }
 }


### PR DESCRIPTION
### In this PR

Moved auction view's data processing to a hook.

#### How it worked before
**Arrays generation**
Auction view arrays are generated every time a component re-renders without any limitations. Even though it needs to show live auctions, it still generates **participated, resaleAuctions, auctionsEnded**

Old code:
```ts
  // Arrays for every type are generated above and then chosed by this switch-case.
  switch (activeKey) {
    case LiveAuctionViewState.All:
      items = liveAuctions;
      break;
    case LiveAuctionViewState.Participated:
      items = participated;
      break;
    case LiveAuctionViewState.Resale:
      items = resaleAuctions;
      break;
    case LiveAuctionViewState.Ended:
      items = auctionsEnded;
      break;
  }
```

**Rendering function**
Each time component renders, two rendering functions are re-creating **liveAuctionsView** and **endedAuctions**. They use related auctions arrays. 


#### How it works in this PR
##### Arrays generation
There is only one array generated based on a selected tab. It's also being memoed. 

```ts
  const auctions = useAuctions();

  const filteredAuctions = useMemo(() => {
    const filterFn = getFilterFunction(activeKey);

    return sortAuctionsByDate(auctions).filter(auction =>
      filterFn(auction, publicKey),
    );
  }, [activeKey, auctions, publicKey]);
```

##### Rendering
Content rendering is not spread out between tabs. There is only one place it's being rendered.

```tsx
<Row>
  <Masonry
    breakpointCols={breakpointColumnsObj}
    className="masonry-grid"
    columnClassName="masonry-grid_column"
  >
    {isLoading &&
      [...Array(10)].map((_, idx) => <CardLoader key={idx} />)}
    {!isLoading &&
      auctions.map((m, idx) => (
        <Link to={`/auction/${m.auction.pubkey}`} key={idx}>
          <AuctionRenderCard
            key={m.auction.pubkey}
            auctionView={m}
          />
        </Link>
      ))}
  </Masonry>
</Row>
```