### PR TITLE
Fixed typo build example in readme

### DIFF
--- a/js/packages/cli/README.md
+++ b/js/packages/cli/README.md
@@ -147,7 +147,9 @@ yarn run package:linuxb
 OR
 yarn run package:linux
 OR
-yarn run package:macos
+yarn run package:macos-x64
+OR
+yarn run package:macos-m1
 ```
 
 You can now either use `metaplex` OR the `ts-node cli` to execute the following commands.


### PR DESCRIPTION
The package.json has build scrips for each macos architecture