### PR TITLE
Fix AUCTION_HOUSE_SIZE calculation

### DIFF
--- a/rust/auction-house/src/lib.rs
+++ b/rust/auction-house/src/lib.rs
@@ -1345,11 +1345,12 @@ pub const AUCTION_HOUSE_SIZE: usize = 8 + //key
 32 + //treasury mint
 32 + //authority
 32 + // creator
-8 + // bump
-8 + // treasury_bump
-8 + // fee_payer_bump
+1 + // bump
+1 + // treasury_bump
+1 + // fee_payer_bump
 2 + // seller fee basis points
 1 + // requires sign off
+1 + // can change sale price
 200; //padding
 
 #[account]

--- a/rust/auction-house/src/lib.rs
+++ b/rust/auction-house/src/lib.rs
@@ -431,7 +431,6 @@ pub mod auction_house {
             FEE_PAYER.as_bytes(),
             &[auction_house.fee_payer_bump],
         ];
-        let auction_house_key = auction_house.key();
         let wallet_key = wallet.key();
 
         let escrow_signer_seeds = [

--- a/rust/auction-house/src/lib.rs
+++ b/rust/auction-house/src/lib.rs
@@ -1350,7 +1350,7 @@ pub const AUCTION_HOUSE_SIZE: usize = 8 + //key
 2 + // seller fee basis points
 1 + // requires sign off
 1 + // can change sale price
-221; //padding
+220; //padding
 
 #[account]
 pub struct AuctionHouse {

--- a/rust/auction-house/src/lib.rs
+++ b/rust/auction-house/src/lib.rs
@@ -1351,7 +1351,7 @@ pub const AUCTION_HOUSE_SIZE: usize = 8 + //key
 2 + // seller fee basis points
 1 + // requires sign off
 1 + // can change sale price
-200; //padding
+221; //padding
 
 #[account]
 pub struct AuctionHouse {


### PR DESCRIPTION
`AUCTION_HOUSE_SIZE` seems to allocate 8 bytes for `u8`s and nothing at all for `can_change_sale_price`. The error itself is all covered by the extra padding but we may as well fix it up properly so its not confusing to read