### PR TITLE
fix: skip graphql package build

### DIFF
--- a/js/packages/graphql/package.json
+++ b/js/packages/graphql/package.json
@@ -9,7 +9,6 @@
     "lint:format": "prettier --write 'src/**/*.{js,ts,json}'",
     "lint:eslint": "eslint 'src/**/*.ts'",
     "lint": "yarn lint:format && yarn lint:eslint --fix",
-    "build": "yarn clean && npm run build:native && npm run build:ts",
     "build:watch": "yarn build -- --watch",
     "build:ts": "tsc",
     "build:native": "cd ingester && yarn && yarn build-release",


### PR DESCRIPTION
* GraphQL package requires Rust to be installed in the environment.
* Skip GraphQL build while running yarn build in the js folder. It can be started in Docker though.
* Fixes Vercel build.

#856 #845 #844