### PR TITLE
fix: fix button after claim purchase

### DIFF
--- a/js/packages/web/src/components/AuctionCard/hooks/useInstantSaleState.ts
+++ b/js/packages/web/src/components/AuctionCard/hooks/useInstantSaleState.ts
@@ -24,10 +24,9 @@ export const useInstantSaleState = (
 
   const isOwner = auctionManager.authority === wallet?.publicKey?.toBase58();
   const isAuctionEnded = auction.info.endedAt;
-  const canClaimPurchasedItem = !!(
-    myBidderPot && !myBidderMetadata?.info.cancelled
-  );
-  const isAlreadyBought = !!(myBidderPot && myBidderMetadata?.info.cancelled);
+  const isBidCanceled = !!myBidderMetadata?.info.cancelled;
+  const canClaimPurchasedItem = !!(myBidderPot && !isBidCanceled);
+  const isAlreadyBought = !!(myBidderPot && isBidCanceled);
   const canClaimItem = !!(isOwner && isAuctionEnded);
   const canEndInstantSale = isOwner && !isAuctionEnded;
 

--- a/js/packages/web/src/components/AuctionCard/hooks/useInstantSaleState.ts
+++ b/js/packages/web/src/components/AuctionCard/hooks/useInstantSaleState.ts
@@ -3,6 +3,7 @@ import { AuctionView } from '../../../hooks';
 
 interface ActionButtonContentProps {
   isInstantSale: boolean;
+  isAlreadyBought: boolean;
   canClaimItem: boolean;
   canClaimPurchasedItem: boolean;
   canEndInstantSale: boolean;
@@ -13,16 +14,26 @@ export const useInstantSaleState = (
 ): ActionButtonContentProps => {
   const wallet = useWallet();
 
-  const { isInstantSale, auctionManager, auction, myBidderPot } = auctionView;
+  const {
+    isInstantSale,
+    auctionManager,
+    auction,
+    myBidderPot,
+    myBidderMetadata,
+  } = auctionView;
 
   const isOwner = auctionManager.authority === wallet?.publicKey?.toBase58();
   const isAuctionEnded = auction.info.endedAt;
-  const canClaimPurchasedItem = !!myBidderPot;
+  const canClaimPurchasedItem = !!(
+    myBidderPot && !myBidderMetadata?.info.cancelled
+  );
+  const isAlreadyBought = !!(myBidderPot && myBidderMetadata?.info.cancelled);
   const canClaimItem = !!(isOwner && isAuctionEnded);
   const canEndInstantSale = isOwner && !isAuctionEnded;
 
   return {
     isInstantSale,
+    isAlreadyBought,
     canClaimItem,
     canClaimPurchasedItem,
     canEndInstantSale,

--- a/js/packages/web/src/components/AuctionCard/index.tsx
+++ b/js/packages/web/src/components/AuctionCard/index.tsx
@@ -640,7 +640,9 @@ export const AuctionCard = ({
                         ? `◎ ${value}`.replace(/\B(?=(\d{3})+(?!\d))/g, ',')
                         : ''
                     }
-                    placeholder={ minBid === 0 ? `Place a Bid` : `Bid ${minBid} SOL or more` }
+                    placeholder={
+                      minBid === 0 ? `Place a Bid` : `Bid ${minBid} SOL or more`
+                    }
                   />
                 </div>
                 <div className={'bid-buttons'}>
@@ -715,12 +717,13 @@ export const AuctionCard = ({
           ) : loading ? (
             <Spin />
           ) : (
-            auctionView.isInstantSale && (
+            auctionView.isInstantSale &&
+            !isAlreadyBought && (
               <Button
                 type="primary"
                 size="large"
                 className="ant-btn secondary-btn"
-                disabled={loading || isAlreadyBought}
+                disabled={loading}
                 onClick={instantSaleAction}
                 style={{ marginTop: 20, width: '100%' }}
               >

--- a/js/packages/web/src/components/AuctionCard/index.tsx
+++ b/js/packages/web/src/components/AuctionCard/index.tsx
@@ -424,7 +424,8 @@ export const AuctionCard = ({
     (auctionView.vault.info.state === VaultState.Deactivated &&
       isBidderPotEmpty);
 
-  const { canEndInstantSale } = useInstantSaleState(auctionView);
+  const { canEndInstantSale, isAlreadyBought } =
+    useInstantSaleState(auctionView);
 
   const actionButtonContent = useActionButtonContent(auctionView);
 
@@ -719,7 +720,7 @@ export const AuctionCard = ({
                 type="primary"
                 size="large"
                 className="ant-btn secondary-btn"
-                disabled={loading}
+                disabled={loading || isAlreadyBought}
                 onClick={instantSaleAction}
                 style={{ marginTop: 20, width: '100%' }}
               >


### PR DESCRIPTION
https://github.com/metaplex-foundation/metaplex/issues/840
That will return button back into "Buy now" state, but will make it disabled cause right now there is no way to make two purchaces in one auction/instant sale