### PR TITLE
chore: fix token-meta tests+clean up code

### DIFF
--- a/rust/auction/program/tests/helpers.rs
+++ b/rust/auction/program/tests/helpers.rs
@@ -1,3 +1,10 @@
+use metaplex_auction::{
+    instruction,
+    processor::{
+        CancelBidArgs, ClaimBidArgs, CreateAuctionArgs, CreateAuctionArgsV2, EndAuctionArgs,
+        PlaceBidArgs, PriceFloor, StartAuctionArgs, WinnerLimit,
+    },
+};
 use solana_program::{hash::Hash, program_pack::Pack, pubkey::Pubkey, system_instruction};
 use solana_program_test::*;
 use solana_sdk::{
@@ -5,13 +12,6 @@ use solana_sdk::{
     signature::{Keypair, Signer},
     transaction::Transaction,
     transport::TransportError,
-};
-use metaplex_auction::{
-    instruction,
-    processor::{
-        CancelBidArgs, ClaimBidArgs, CreateAuctionArgs, CreateAuctionArgsV2, EndAuctionArgs,
-        PlaceBidArgs, PriceFloor, StartAuctionArgs, WinnerLimit,
-    },
 };
 
 fn string_to_array(value: &str) -> Result<[u8; 32], TransportError> {
@@ -172,7 +172,7 @@ pub async fn create_auction(
                     price_floor,
                     gap_tick_size_percentage,
                     tick_size,
-                    name: string_to_array(name)?,
+                    name: Some(string_to_array(name)?),
                     instant_sale_price,
                 },
             )],
@@ -365,6 +365,7 @@ pub async fn claim_bid(
             bidder.pubkey(),
             bidder_spl_account.pubkey(),
             *mint,
+            None,
             ClaimBidArgs {
                 resource: *resource,
             },

--- a/rust/token-metadata/program/rustfmt.toml
+++ b/rust/token-metadata/program/rustfmt.toml
@@ -1,0 +1,9 @@
+edition = "2018"
+max_width = 100 
+imports_indent = "Block"
+imports_layout = "Mixed"
+imports_granularity = "Crate"
+group_imports = "Preserve"
+reorder_imports = true
+reorder_modules = true
+reorder_impl_items = false

--- a/rust/token-metadata/program/src/deprecated_instruction.rs
+++ b/rust/token-metadata/program/src/deprecated_instruction.rs
@@ -1,14 +1,12 @@
-use {
-    crate::{
-        instruction::{CreateMasterEditionArgs, MetadataInstruction},
-        state::Reservation,
-    },
-    borsh::{BorshDeserialize, BorshSerialize},
-    solana_program::{
-        instruction::{AccountMeta, Instruction},
-        pubkey::Pubkey,
-        sysvar,
-    },
+use crate::{
+    instruction::{CreateMasterEditionArgs, MetadataInstruction},
+    state::Reservation,
+};
+use borsh::{BorshDeserialize, BorshSerialize};
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+    sysvar,
 };
 
 #[repr(C)]

--- a/rust/token-metadata/program/src/deprecated_processor.rs
+++ b/rust/token-metadata/program/src/deprecated_processor.rs
@@ -1,31 +1,29 @@
 use solana_program::msg;
 
-use {
-    crate::{
-        error::MetadataError,
-        state::{
-            get_reservation_list, Key, MasterEditionV1, Metadata, Reservation, ReservationListV2,
-            EDITION, MAX_MASTER_EDITION_LEN, MAX_RESERVATIONS, MAX_RESERVATION_LIST_SIZE, PREFIX,
-            RESERVATION,
-        },
-        utils::{
-            assert_derivation, assert_initialized, assert_mint_authority_matches_mint,
-            assert_owned_by, assert_rent_exempt, assert_signer, assert_supply_invariance,
-            assert_token_program_matches_package, assert_update_authority_is_correct,
-            create_or_allocate_account_raw, mint_limited_edition, spl_token_burn,
-            spl_token_mint_to, transfer_mint_authority, TokenBurnParams, TokenMintToParams,
-        },
+use crate::{
+    error::MetadataError,
+    state::{
+        get_reservation_list, Key, MasterEditionV1, Metadata, Reservation, ReservationListV2,
+        EDITION, MAX_MASTER_EDITION_LEN, MAX_RESERVATIONS, MAX_RESERVATION_LIST_SIZE, PREFIX,
+        RESERVATION,
     },
-    borsh::BorshSerialize,
-    solana_program::{
-        account_info::{next_account_info, AccountInfo},
-        entrypoint::ProgramResult,
-        pubkey::Pubkey,
-        rent::Rent,
-        sysvar::Sysvar,
+    utils::{
+        assert_derivation, assert_initialized, assert_mint_authority_matches_mint, assert_owned_by,
+        assert_rent_exempt, assert_signer, assert_supply_invariance,
+        assert_token_program_matches_package, assert_update_authority_is_correct,
+        create_or_allocate_account_raw, mint_limited_edition, spl_token_burn, spl_token_mint_to,
+        transfer_mint_authority, TokenBurnParams, TokenMintToParams,
     },
-    spl_token::state::{Account, Mint},
 };
+use borsh::BorshSerialize;
+use solana_program::{
+    account_info::{next_account_info, AccountInfo},
+    entrypoint::ProgramResult,
+    pubkey::Pubkey,
+    rent::Rent,
+    sysvar::Sysvar,
+};
+use spl_token::state::{Account, Mint};
 
 /// Create master edition
 pub fn process_deprecated_create_master_edition(

--- a/rust/token-metadata/program/src/entrypoint.rs
+++ b/rust/token-metadata/program/src/entrypoint.rs
@@ -2,12 +2,10 @@
 
 #![cfg(all(target_arch = "bpf", not(feature = "no-entrypoint")))]
 
-use {
-    crate::{error::MetadataError, processor},
-    solana_program::{
-        account_info::AccountInfo, entrypoint, entrypoint::ProgramResult,
-        program_error::PrintProgramError, pubkey::Pubkey,
-    },
+use crate::{error::MetadataError, processor};
+use solana_program::{
+    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult,
+    program_error::PrintProgramError, pubkey::Pubkey,
 };
 
 entrypoint!(process_instruction);

--- a/rust/token-metadata/program/src/error.rs
+++ b/rust/token-metadata/program/src/error.rs
@@ -1,14 +1,12 @@
 //! Error types
 
-use {
-    num_derive::FromPrimitive,
-    solana_program::{
-        decode_error::DecodeError,
-        msg,
-        program_error::{PrintProgramError, ProgramError},
-    },
-    thiserror::Error,
+use num_derive::FromPrimitive;
+use solana_program::{
+    decode_error::DecodeError,
+    msg,
+    program_error::{PrintProgramError, ProgramError},
 };
+use thiserror::Error;
 
 /// Errors that may be returned by the Metadata program.
 #[derive(Clone, Debug, Eq, Error, FromPrimitive, PartialEq)]

--- a/rust/token-metadata/program/src/instruction.rs
+++ b/rust/token-metadata/program/src/instruction.rs
@@ -1,14 +1,12 @@
-use {
-    crate::{
-        deprecated_instruction::{MintPrintingTokensViaTokenArgs, SetReservationListArgs},
-        state::{Creator, Data, EDITION, EDITION_MARKER_BIT_SIZE, PREFIX},
-    },
-    borsh::{BorshDeserialize, BorshSerialize},
-    solana_program::{
-        instruction::{AccountMeta, Instruction},
-        pubkey::Pubkey,
-        sysvar,
-    },
+use crate::{
+    deprecated_instruction::{MintPrintingTokensViaTokenArgs, SetReservationListArgs},
+    state::{Creator, Data, EDITION, EDITION_MARKER_BIT_SIZE, PREFIX},
+};
+use borsh::{BorshDeserialize, BorshSerialize};
+use solana_program::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+    sysvar,
 };
 
 #[repr(C)]

--- a/rust/token-metadata/program/src/lib.rs
+++ b/rust/token-metadata/program/src/lib.rs
@@ -8,6 +8,7 @@ pub mod instruction;
 pub mod processor;
 pub mod state;
 pub mod utils;
+pub mod utils_test;
 // Export current sdk types for downstream users building with a different sdk version
 pub use solana_program;
 

--- a/rust/token-metadata/program/src/processor.rs
+++ b/rust/token-metadata/program/src/processor.rs
@@ -1,41 +1,38 @@
-use {
-    crate::{
-        deprecated_processor::{
-            process_deprecated_create_master_edition, process_deprecated_create_reservation_list,
-            process_deprecated_mint_new_edition_from_master_edition_via_printing_token,
-            process_deprecated_mint_printing_tokens,
-            process_deprecated_mint_printing_tokens_via_token,
-            process_deprecated_set_reservation_list,
-        },
-        error::MetadataError,
-        instruction::MetadataInstruction,
-        state::{
-            Data, Key, MasterEditionV1, MasterEditionV2, Metadata, EDITION, MAX_MASTER_EDITION_LEN,
-            PREFIX,
-        },
-        utils::{
-            assert_data_valid, assert_derivation, assert_initialized,
-            assert_mint_authority_matches_mint, assert_owned_by, assert_signer,
-            assert_token_program_matches_package, assert_update_authority_is_correct,
-            create_or_allocate_account_raw, get_owner_from_token_account,
-            process_create_metadata_accounts_logic,
-            process_mint_new_edition_from_master_edition_via_token_logic, puff_out_data_fields,
-            transfer_mint_authority, CreateMetadataAccountsLogicArgs,
-            MintNewEditionFromMasterEditionViaTokenLogicArgs,
-        },
+use crate::{
+    deprecated_processor::{
+        process_deprecated_create_master_edition, process_deprecated_create_reservation_list,
+        process_deprecated_mint_new_edition_from_master_edition_via_printing_token,
+        process_deprecated_mint_printing_tokens, process_deprecated_mint_printing_tokens_via_token,
+        process_deprecated_set_reservation_list,
     },
-    arrayref::array_ref,
-    borsh::{BorshDeserialize, BorshSerialize},
-    solana_program::{
-        account_info::{next_account_info, AccountInfo},
-        entrypoint::ProgramResult,
-        msg,
-        program_error::ProgramError,
-        pubkey::Pubkey,
+    error::MetadataError,
+    instruction::MetadataInstruction,
+    state::{
+        Data, Key, MasterEditionV1, MasterEditionV2, Metadata, EDITION, MAX_MASTER_EDITION_LEN,
+        PREFIX,
     },
-    spl_token::state::{Account, Mint},
-    metaplex_token_vault::{error::VaultError, state::VaultState},
+    utils::{
+        assert_data_valid, assert_derivation, assert_initialized,
+        assert_mint_authority_matches_mint, assert_owned_by, assert_signer,
+        assert_token_program_matches_package, assert_update_authority_is_correct,
+        create_or_allocate_account_raw, get_owner_from_token_account,
+        process_create_metadata_accounts_logic,
+        process_mint_new_edition_from_master_edition_via_token_logic, puff_out_data_fields,
+        transfer_mint_authority, CreateMetadataAccountsLogicArgs,
+        MintNewEditionFromMasterEditionViaTokenLogicArgs,
+    },
 };
+use arrayref::array_ref;
+use borsh::{BorshDeserialize, BorshSerialize};
+use metaplex_token_vault::{error::VaultError, state::VaultState};
+use solana_program::{
+    account_info::{next_account_info, AccountInfo},
+    entrypoint::ProgramResult,
+    msg,
+    program_error::ProgramError,
+    pubkey::Pubkey,
+};
+use spl_token::state::{Account, Mint};
 
 pub fn process_instruction<'a>(
     program_id: &'a Pubkey,
@@ -195,7 +192,7 @@ pub fn process_update_metadata_accounts(
                 &metadata,
                 false,
                 update_authority_info.is_signer,
-                true
+                true,
             )?;
             metadata.data = data;
         } else {

--- a/rust/token-metadata/program/src/state.rs
+++ b/rust/token-metadata/program/src/state.rs
@@ -1,10 +1,8 @@
-use {
-    crate::{error::MetadataError, utils::try_from_slice_checked},
-    borsh::{BorshDeserialize, BorshSerialize},
-    solana_program::{
-        account_info::AccountInfo, entrypoint::ProgramResult, program_error::ProgramError,
-        pubkey::Pubkey,
-    },
+use crate::{error::MetadataError, utils::try_from_slice_checked};
+use borsh::{BorshDeserialize, BorshSerialize};
+use solana_program::{
+    account_info::AccountInfo, entrypoint::ProgramResult, program_error::ProgramError,
+    pubkey::Pubkey,
 };
 /// prefix used for PDAs to avoid certain collision attacks (https://en.wikipedia.org/wiki/Collision_attack#Chosen-prefix_collision_attack)
 pub const PREFIX: &str = "metadata";

--- a/rust/token-metadata/program/src/utils.rs
+++ b/rust/token-metadata/program/src/utils.rs
@@ -903,25 +903,9 @@ pub fn process_create_metadata_accounts_logic(
 /// Strings need to be appended with `\0`s in order to have a deterministic length.
 /// This supports the `memcmp` filter  on get program account calls.
 pub fn puff_out_data_fields(metadata: &mut Metadata) {
-    let mut array_of_zeroes = vec![];
-    while array_of_zeroes.len() < MAX_NAME_LENGTH - metadata.data.name.len() {
-        array_of_zeroes.push(0u8);
-    }
-    metadata.data.name =
-        metadata.data.name.clone() + std::str::from_utf8(&array_of_zeroes).unwrap();
-
-    let mut array_of_zeroes = vec![];
-    while array_of_zeroes.len() < MAX_SYMBOL_LENGTH - metadata.data.symbol.len() {
-        array_of_zeroes.push(0u8);
-    }
-    metadata.data.symbol =
-        metadata.data.symbol.clone() + std::str::from_utf8(&array_of_zeroes).unwrap();
-
-    let mut array_of_zeroes = vec![];
-    while array_of_zeroes.len() < MAX_URI_LENGTH - metadata.data.uri.len() {
-        array_of_zeroes.push(0u8);
-    }
-    metadata.data.uri = metadata.data.uri.clone() + std::str::from_utf8(&array_of_zeroes).unwrap();
+    metadata.data.name = puffed_out_string(&metadata.data.name, MAX_NAME_LENGTH);
+    metadata.data.symbol = puffed_out_string(&metadata.data.symbol, MAX_SYMBOL_LENGTH);
+    metadata.data.uri = puffed_out_string(&metadata.data.uri, MAX_URI_LENGTH);
 }
 
 pub fn puffed_out_string(s: &String, size: usize) -> String {

--- a/rust/token-metadata/program/src/utils.rs
+++ b/rust/token-metadata/program/src/utils.rs
@@ -1,34 +1,32 @@
-use {
-    arrayref::{array_mut_ref, array_ref, array_refs, mut_array_refs},
-    borsh::{BorshDeserialize, BorshSerialize},
-    crate::{
-        error::MetadataError,
-        state::{
-            get_reservation_list, Data, EditionMarker, Key, MasterEditionV1, Metadata, EDITION,
-            EDITION_MARKER_BIT_SIZE, MAX_CREATOR_LIMIT, MAX_EDITION_LEN, MAX_EDITION_MARKER_SIZE,
-            MAX_MASTER_EDITION_LEN, MAX_METADATA_LEN, MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH,
-            MAX_URI_LENGTH, PREFIX,
-        },
+use crate::{
+    error::MetadataError,
+    state::{
+        get_reservation_list, Data, EditionMarker, Key, MasterEditionV1, Metadata, EDITION,
+        EDITION_MARKER_BIT_SIZE, MAX_CREATOR_LIMIT, MAX_EDITION_LEN, MAX_EDITION_MARKER_SIZE,
+        MAX_MASTER_EDITION_LEN, MAX_METADATA_LEN, MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH,
+        MAX_URI_LENGTH, PREFIX,
     },
-    solana_program::{
-        account_info::AccountInfo,
-        borsh::try_from_slice_unchecked,
-        entrypoint::ProgramResult,
-        msg,
-        program::{invoke, invoke_signed},
-        program_error::ProgramError,
-        program_option::COption,
-        program_pack::{IsInitialized, Pack},
-        pubkey::Pubkey,
-        system_instruction,
-        sysvar::{rent::Rent, Sysvar},
-    },
-    spl_token::{
-        instruction::{set_authority, AuthorityType},
-        state::{Account, Mint},
-    },
-    std::convert::TryInto,
 };
+use arrayref::{array_mut_ref, array_ref, array_refs, mut_array_refs};
+use borsh::{BorshDeserialize, BorshSerialize};
+use solana_program::{
+    account_info::AccountInfo,
+    borsh::try_from_slice_unchecked,
+    entrypoint::ProgramResult,
+    msg,
+    program::{invoke, invoke_signed},
+    program_error::ProgramError,
+    program_option::COption,
+    program_pack::{IsInitialized, Pack},
+    pubkey::Pubkey,
+    system_instruction,
+    sysvar::{rent::Rent, Sysvar},
+};
+use spl_token::{
+    instruction::{set_authority, AuthorityType},
+    state::{Account, Mint},
+};
+use std::convert::TryInto;
 
 pub fn assert_data_valid(
     data: &Data,

--- a/rust/token-metadata/program/src/utils.rs
+++ b/rust/token-metadata/program/src/utils.rs
@@ -823,19 +823,21 @@ pub fn process_create_metadata_accounts_logic(
     let existing_mint_authority = get_mint_authority(mint_info)?;
     // IMPORTANT NOTE
     // This allows the Metaplex Foundation to Create but not update metadata for SPL tokens that have not populated their metadata.
-    assert_mint_authority_matches_mint(&existing_mint_authority, mint_authority_info).or_else(|e| {
-        // Allow seeding by the authority seed populator
-        if mint_authority_info.key == &SEED_AUTHORITY && mint_authority_info.is_signer {
-            // When metadata is seeded, the mint authority should be able to change it
-            if let COption::Some(auth) = existing_mint_authority {
-                update_authority_key = auth;
-                is_mutable = true;
+    assert_mint_authority_matches_mint(&existing_mint_authority, mint_authority_info).or_else(
+        |e| {
+            // Allow seeding by the authority seed populator
+            if mint_authority_info.key == &SEED_AUTHORITY && mint_authority_info.is_signer {
+                // When metadata is seeded, the mint authority should be able to change it
+                if let COption::Some(auth) = existing_mint_authority {
+                    update_authority_key = auth;
+                    is_mutable = true;
+                }
+                Ok(())
+            } else {
+                Err(e)
             }
-            Ok(())
-        } else {
-            Err(e)
-        }
-    })?;
+        },
+    )?;
     assert_owned_by(mint_info, &spl_token::id())?;
 
     let metadata_seeds = &[
@@ -898,6 +900,8 @@ pub fn process_create_metadata_accounts_logic(
     Ok(())
 }
 
+/// Strings need to be appended with `\0`s in order to have a deterministic length.
+/// This supports the `memcmp` filter  on get program account calls.
 pub fn puff_out_data_fields(metadata: &mut Metadata) {
     let mut array_of_zeroes = vec![];
     while array_of_zeroes.len() < MAX_NAME_LENGTH - metadata.data.name.len() {

--- a/rust/token-metadata/program/src/utils.rs
+++ b/rust/token-metadata/program/src/utils.rs
@@ -924,6 +924,15 @@ pub fn puff_out_data_fields(metadata: &mut Metadata) {
     metadata.data.uri = metadata.data.uri.clone() + std::str::from_utf8(&array_of_zeroes).unwrap();
 }
 
+pub fn puffed_out_string(s: &String, size: usize) -> String {
+    let mut array_of_zeroes = vec![];
+    let puff_amount = size - s.len();
+    while array_of_zeroes.len() < puff_amount {
+        array_of_zeroes.push(0u8);
+    }
+    s.clone() + std::str::from_utf8(&array_of_zeroes).unwrap()
+}
+
 pub struct MintNewEditionFromMasterEditionViaTokenLogicArgs<'a> {
     pub new_metadata_account_info: &'a AccountInfo<'a>,
     pub new_edition_account_info: &'a AccountInfo<'a>,

--- a/rust/token-metadata/program/src/utils.rs
+++ b/rust/token-metadata/program/src/utils.rs
@@ -900,12 +900,15 @@ pub fn process_create_metadata_accounts_logic(
 
 /// Strings need to be appended with `\0`s in order to have a deterministic length.
 /// This supports the `memcmp` filter  on get program account calls.
+/// NOTE: it is assumed that the metadata fields are never larger than the respective MAX_LENGTH
 pub fn puff_out_data_fields(metadata: &mut Metadata) {
     metadata.data.name = puffed_out_string(&metadata.data.name, MAX_NAME_LENGTH);
     metadata.data.symbol = puffed_out_string(&metadata.data.symbol, MAX_SYMBOL_LENGTH);
     metadata.data.uri = puffed_out_string(&metadata.data.uri, MAX_URI_LENGTH);
 }
 
+/// Pads the string to the desired size with `0u8`s.
+/// NOTE: it is assumed that the string's size is never larger than the given size.
 pub fn puffed_out_string(s: &String, size: usize) -> String {
     let mut array_of_zeroes = vec![];
     let puff_amount = size - s.len();

--- a/rust/token-metadata/program/src/utils_test.rs
+++ b/rust/token-metadata/program/src/utils_test.rs
@@ -1,0 +1,63 @@
+#![cfg(test)]
+
+mod puff_out_test {
+    use solana_program::pubkey::Pubkey;
+
+    use crate::{
+        state::{Data, Key, Metadata},
+        utils::{puff_out_data_fields, puffed_out_string},
+    };
+
+    #[test]
+    fn puffed_out_string_test() {
+        let cases = &[
+            ("hello", 5, "hello"),
+            ("hello", 6, "hello\u{0}"),
+            ("hello", 10, "hello\u{0}\u{0}\u{0}\u{0}\u{0}"),
+            (
+                "hello",
+                20,
+                "hello\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}",
+            ),
+        ];
+        for (s, size, puffed_out) in cases {
+            let result = puffed_out_string(&s.to_string(), *size);
+            assert_eq!(result, puffed_out.to_string(), "s: {:?}, size: {}", s, size,);
+        }
+    }
+
+    #[test]
+    fn puffed_out_metadata_test() {
+        let mut metadata = Metadata {
+            key: Key::Uninitialized,
+            update_authority: Pubkey::new_unique(),
+            mint: Pubkey::new_unique(),
+            data: Data {
+                name: "Garfield".to_string(),
+                symbol: "GARF".to_string(),
+                uri: "https://garfiel.de".to_string(),
+                seller_fee_basis_points: 0,
+                creators: None,
+            },
+            primary_sale_happened: false,
+            is_mutable: false,
+            edition_nonce: None,
+        };
+
+        puff_out_data_fields(&mut metadata);
+
+        let Data {
+            name,
+            symbol,
+            uri,
+            seller_fee_basis_points,
+            creators,
+        } = metadata.data;
+
+        assert_eq!(name.as_str(), "Garfield\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}");
+        assert_eq!(symbol.as_str(), "GARF\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}");
+        assert_eq!(uri.as_str(), "https://garfiel.de\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}");
+        assert_eq!(seller_fee_basis_points, 0);
+        assert_eq!(creators, None);
+    }
+}

--- a/rust/token-metadata/program/tests/create_master_edition.rs
+++ b/rust/token-metadata/program/tests/create_master_edition.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "test-bpf")]
 mod utils;
 
 use metaplex_token_metadata::{error::MetadataError, id, instruction, state::Key};

--- a/rust/token-metadata/program/tests/create_master_edition.rs
+++ b/rust/token-metadata/program/tests/create_master_edition.rs
@@ -14,215 +14,219 @@ use metaplex_token_metadata::state::Key;
 use metaplex_token_metadata::{id, instruction};
 use utils::*;
 
-#[tokio::test]
-async fn success() {
-    let mut context = program_test().start_with_context().await;
-    let test_metadata = Metadata::new();
-    let test_master_edition = MasterEditionV2::new(&test_metadata);
+mod create_master_edition {
+    use super::*;
 
-    test_metadata
-        .create(
+    #[tokio::test]
+    async fn success() {
+        let mut context = program_test().start_with_context().await;
+        let test_metadata = Metadata::new();
+        let test_master_edition = MasterEditionV2::new(&test_metadata);
+
+        test_metadata
+            .create(
+                &mut context,
+                "Test".to_string(),
+                "TST".to_string(),
+                "uri".to_string(),
+                None,
+                10,
+                false,
+            )
+            .await
+            .unwrap();
+
+        let mint = get_mint(&mut context, &test_master_edition.mint_pubkey).await;
+        let old_authority = mint.mint_authority.unwrap();
+
+        test_master_edition
+            .create(&mut context, Some(10))
+            .await
+            .unwrap();
+
+        let master_edition = test_master_edition.get_data(&mut context).await;
+
+        let mint = get_mint(&mut context, &test_master_edition.mint_pubkey).await;
+        let new_authority = mint.mint_authority.unwrap();
+
+        assert_eq!(new_authority, new_authority);
+        assert_ne!(old_authority, new_authority);
+        assert_eq!(master_edition.supply, 0);
+        assert_eq!(master_edition.max_supply.unwrap(), 10);
+        assert_eq!(master_edition.key, Key::MasterEditionV2);
+    }
+
+    #[tokio::test]
+    async fn fail_invalid_mint_authority() {
+        let mut context = program_test().start_with_context().await;
+        let test_metadata = Metadata::new();
+        let test_master_edition = MasterEditionV2::new(&test_metadata);
+        let fake_mint_authority = Keypair::new();
+
+        test_metadata
+            .create(
+                &mut context,
+                "Test".to_string(),
+                "TST".to_string(),
+                "uri".to_string(),
+                None,
+                10,
+                false,
+            )
+            .await
+            .unwrap();
+
+        let tx = Transaction::new_signed_with_payer(
+            &[instruction::create_master_edition(
+                id(),
+                test_master_edition.pubkey,
+                test_master_edition.mint_pubkey,
+                context.payer.pubkey(),
+                fake_mint_authority.pubkey(),
+                test_master_edition.metadata_pubkey,
+                context.payer.pubkey(),
+                Some(10),
+            )],
+            Some(&context.payer.pubkey()),
+            &[&context.payer, &context.payer, &fake_mint_authority],
+            context.last_blockhash,
+        );
+
+        let result = context
+            .banks_client
+            .process_transaction(tx)
+            .await
+            .unwrap_err();
+
+        assert_custom_error!(result, MetadataError::InvalidMintAuthority);
+    }
+
+    #[tokio::test]
+    async fn fail_invalid_token_program() {
+        let mut context = program_test().start_with_context().await;
+        let test_metadata = Metadata::new();
+        let test_master_edition = MasterEditionV2::new(&test_metadata);
+
+        test_metadata
+            .create(
+                &mut context,
+                "Test".to_string(),
+                "TST".to_string(),
+                "uri".to_string(),
+                None,
+                10,
+                false,
+            )
+            .await
+            .unwrap();
+
+        let result = test_master_edition
+            .create_with_invalid_token_program(&mut context, Some(10))
+            .await
+            .unwrap_err();
+        assert_custom_error!(result, MetadataError::InvalidTokenProgram);
+    }
+
+    #[tokio::test]
+    async fn fail_invalid_mint() {
+        let mut context = program_test().start_with_context().await;
+        let test_metadata = Metadata::new();
+
+        let fake_mint = Keypair::new();
+        let fake_account = Keypair::new();
+        let payer_pubkey = context.payer.pubkey();
+
+        test_metadata
+            .create(
+                &mut context,
+                "Test".to_string(),
+                "TST".to_string(),
+                "uri".to_string(),
+                None,
+                10,
+                false,
+            )
+            .await
+            .unwrap();
+
+        create_mint(&mut context, &fake_mint, &payer_pubkey, None)
+            .await
+            .unwrap();
+        create_token_account(
             &mut context,
-            "Test".to_string(),
-            "TST".to_string(),
-            "uri".to_string(),
+            &fake_account,
+            &fake_mint.pubkey(),
+            &payer_pubkey,
+        )
+        .await
+        .unwrap();
+        mint_tokens(
+            &mut context,
+            &fake_mint.pubkey(),
+            &fake_account.pubkey(),
+            1000000,
+            &payer_pubkey,
             None,
-            10,
-            false,
         )
         .await
         .unwrap();
 
-    let mint = get_mint(&mut context, &test_master_edition.mint_pubkey).await;
-    let old_authority = mint.mint_authority.unwrap();
+        let test_master_edition = MasterEditionV2::new(&Metadata {
+            mint: fake_mint,
+            pubkey: test_metadata.pubkey.clone(),
+            token: fake_account,
+        });
 
-    test_master_edition
-        .create(&mut context, Some(10))
-        .await
-        .unwrap();
+        let result = test_master_edition
+            .create(&mut context, Some(10))
+            .await
+            .unwrap_err();
 
-    let master_edition = test_master_edition.get_data(&mut context).await;
+        assert_custom_error!(result, MetadataError::MintMismatch);
+    }
 
-    let mint = get_mint(&mut context, &test_master_edition.mint_pubkey).await;
-    let new_authority = mint.mint_authority.unwrap();
+    #[tokio::test]
+    async fn fail_invalid_update_authority() {
+        let mut context = program_test().start_with_context().await;
+        let test_metadata = Metadata::new();
+        let test_master_edition = MasterEditionV2::new(&test_metadata);
+        let fake_update_authority = Keypair::new();
 
-    assert_eq!(new_authority, new_authority);
-    assert_ne!(old_authority, new_authority);
-    assert_eq!(master_edition.supply, 0);
-    assert_eq!(master_edition.max_supply.unwrap(), 10);
-    assert_eq!(master_edition.key, Key::MasterEditionV2);
-}
+        test_metadata
+            .create(
+                &mut context,
+                "Test".to_string(),
+                "TST".to_string(),
+                "uri".to_string(),
+                None,
+                10,
+                false,
+            )
+            .await
+            .unwrap();
 
-#[tokio::test]
-async fn fail_invalid_mint_authority() {
-    let mut context = program_test().start_with_context().await;
-    let test_metadata = Metadata::new();
-    let test_master_edition = MasterEditionV2::new(&test_metadata);
-    let fake_mint_authority = Keypair::new();
+        let tx = Transaction::new_signed_with_payer(
+            &[instruction::create_master_edition(
+                id(),
+                test_master_edition.pubkey,
+                test_master_edition.mint_pubkey,
+                fake_update_authority.pubkey(),
+                context.payer.pubkey(),
+                test_master_edition.metadata_pubkey,
+                context.payer.pubkey(),
+                Some(10),
+            )],
+            Some(&context.payer.pubkey()),
+            &[&context.payer, &context.payer, &fake_update_authority],
+            context.last_blockhash,
+        );
 
-    test_metadata
-        .create(
-            &mut context,
-            "Test".to_string(),
-            "TST".to_string(),
-            "uri".to_string(),
-            None,
-            10,
-            false,
-        )
-        .await
-        .unwrap();
+        let result = context
+            .banks_client
+            .process_transaction(tx)
+            .await
+            .unwrap_err();
 
-    let tx = Transaction::new_signed_with_payer(
-        &[instruction::create_master_edition(
-            id(),
-            test_master_edition.pubkey,
-            test_master_edition.mint_pubkey,
-            context.payer.pubkey(),
-            fake_mint_authority.pubkey(),
-            test_master_edition.metadata_pubkey,
-            context.payer.pubkey(),
-            Some(10),
-        )],
-        Some(&context.payer.pubkey()),
-        &[&context.payer, &context.payer, &fake_mint_authority],
-        context.last_blockhash,
-    );
-
-    let result = context
-        .banks_client
-        .process_transaction(tx)
-        .await
-        .unwrap_err();
-
-    assert_custom_error!(result, MetadataError::InvalidMintAuthority);
-}
-
-#[tokio::test]
-async fn fail_invalid_token_program() {
-    let mut context = program_test().start_with_context().await;
-    let test_metadata = Metadata::new();
-    let test_master_edition = MasterEditionV2::new(&test_metadata);
-
-    test_metadata
-        .create(
-            &mut context,
-            "Test".to_string(),
-            "TST".to_string(),
-            "uri".to_string(),
-            None,
-            10,
-            false,
-        )
-        .await
-        .unwrap();
-
-    let result = test_master_edition
-        .create_with_invalid_token_program(&mut context, Some(10))
-        .await
-        .unwrap_err();
-    assert_custom_error!(result, MetadataError::InvalidTokenProgram);
-}
-
-#[tokio::test]
-async fn fail_invalid_mint() {
-    let mut context = program_test().start_with_context().await;
-    let test_metadata = Metadata::new();
-
-    let fake_mint = Keypair::new();
-    let fake_account = Keypair::new();
-    let payer_pubkey = context.payer.pubkey();
-
-    test_metadata
-        .create(
-            &mut context,
-            "Test".to_string(),
-            "TST".to_string(),
-            "uri".to_string(),
-            None,
-            10,
-            false,
-        )
-        .await
-        .unwrap();
-
-    create_mint(&mut context, &fake_mint, &payer_pubkey, None)
-        .await
-        .unwrap();
-    create_token_account(
-        &mut context,
-        &fake_account,
-        &fake_mint.pubkey(),
-        &payer_pubkey,
-    )
-    .await
-    .unwrap();
-    mint_tokens(
-        &mut context,
-        &fake_mint.pubkey(),
-        &fake_account.pubkey(),
-        1000000,
-        &payer_pubkey,
-        None,
-    )
-    .await
-    .unwrap();
-
-    let test_master_edition = MasterEditionV2::new(&Metadata {
-        mint: fake_mint,
-        pubkey: test_metadata.pubkey.clone(),
-        token: fake_account,
-    });
-
-    let result = test_master_edition
-        .create(&mut context, Some(10))
-        .await
-        .unwrap_err();
-
-    assert_custom_error!(result, MetadataError::MintMismatch);
-}
-
-#[tokio::test]
-async fn fail_invalid_update_authority() {
-    let mut context = program_test().start_with_context().await;
-    let test_metadata = Metadata::new();
-    let test_master_edition = MasterEditionV2::new(&test_metadata);
-    let fake_update_authority = Keypair::new();
-
-    test_metadata
-        .create(
-            &mut context,
-            "Test".to_string(),
-            "TST".to_string(),
-            "uri".to_string(),
-            None,
-            10,
-            false,
-        )
-        .await
-        .unwrap();
-
-    let tx = Transaction::new_signed_with_payer(
-        &[instruction::create_master_edition(
-            id(),
-            test_master_edition.pubkey,
-            test_master_edition.mint_pubkey,
-            fake_update_authority.pubkey(),
-            context.payer.pubkey(),
-            test_master_edition.metadata_pubkey,
-            context.payer.pubkey(),
-            Some(10),
-        )],
-        Some(&context.payer.pubkey()),
-        &[&context.payer, &context.payer, &fake_update_authority],
-        context.last_blockhash,
-    );
-
-    let result = context
-        .banks_client
-        .process_transaction(tx)
-        .await
-        .unwrap_err();
-
-    assert_custom_error!(result, MetadataError::UpdateAuthorityIncorrect);
+        assert_custom_error!(result, MetadataError::UpdateAuthorityIncorrect);
+    }
 }

--- a/rust/token-metadata/program/tests/create_master_edition.rs
+++ b/rust/token-metadata/program/tests/create_master_edition.rs
@@ -1,17 +1,14 @@
 mod utils;
 
+use metaplex_token_metadata::{error::MetadataError, id, instruction, state::Key};
 use num_traits::FromPrimitive;
 use solana_program_test::*;
-use solana_sdk::signature::Keypair;
 use solana_sdk::{
     instruction::InstructionError,
-    signature::Signer,
+    signature::{Keypair, Signer},
     transaction::{Transaction, TransactionError},
     transport::TransportError,
 };
-use metaplex_token_metadata::error::MetadataError;
-use metaplex_token_metadata::state::Key;
-use metaplex_token_metadata::{id, instruction};
 use utils::*;
 
 mod create_master_edition {

--- a/rust/token-metadata/program/tests/create_metadata_account.rs
+++ b/rust/token-metadata/program/tests/create_metadata_account.rs
@@ -1,5 +1,11 @@
 mod utils;
 
+use metaplex_token_metadata::{
+    error::MetadataError,
+    id, instruction,
+    state::{Key, MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH, MAX_URI_LENGTH},
+    utils::puffed_out_string,
+};
 use num_traits::FromPrimitive;
 use solana_program::pubkey::Pubkey;
 use solana_program_test::*;
@@ -9,14 +15,6 @@ use solana_sdk::{
     transaction::{Transaction, TransactionError},
     transport::TransportError,
 };
-use metaplex_token_metadata::{
-    error::MetadataError,
-    state::{MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH, MAX_URI_LENGTH},
-    utils::puffed_out_string,
-};
-use metaplex_token_metadata::state::Key;
-use metaplex_token_metadata::instruction;
-use metaplex_token_metadata::id;
 use utils::*;
 
 mod create_meta_accounts {

--- a/rust/token-metadata/program/tests/create_metadata_account.rs
+++ b/rust/token-metadata/program/tests/create_metadata_account.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "test-bpf")]
 mod utils;
 
 use metaplex_token_metadata::{

--- a/rust/token-metadata/program/tests/create_metadata_account.rs
+++ b/rust/token-metadata/program/tests/create_metadata_account.rs
@@ -1,6 +1,5 @@
 mod utils;
 
-use borsh::BorshDeserialize;
 use num_traits::FromPrimitive;
 use solana_program::pubkey::Pubkey;
 use solana_program_test::*;
@@ -12,7 +11,6 @@ use solana_sdk::{
 };
 use metaplex_token_metadata::{
     error::MetadataError,
-    instruction::MetadataInstruction,
     state::{MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH, MAX_URI_LENGTH},
     utils::puffed_out_string,
 };
@@ -21,117 +19,120 @@ use metaplex_token_metadata::instruction;
 use metaplex_token_metadata::id;
 use utils::*;
 
-#[tokio::test]
-async fn success() {
-    let mut context = program_test().start_with_context().await;
-    let test_metadata = Metadata::new();
-    let name = "Test".to_string();
-    let symbol = "TST".to_string();
-    let uri = "uri".to_string();
+mod create_meta_accounts {
+    use super::*;
+    #[tokio::test]
+    async fn success() {
+        let mut context = program_test().start_with_context().await;
+        let test_metadata = Metadata::new();
+        let name = "Test".to_string();
+        let symbol = "TST".to_string();
+        let uri = "uri".to_string();
 
-    let puffed_name = puffed_out_string(&name, MAX_NAME_LENGTH);
-    let puffed_symbol = puffed_out_string(&symbol, MAX_SYMBOL_LENGTH);
-    let puffed_uri = puffed_out_string(&uri, MAX_URI_LENGTH);
+        let puffed_name = puffed_out_string(&name, MAX_NAME_LENGTH);
+        let puffed_symbol = puffed_out_string(&symbol, MAX_SYMBOL_LENGTH);
+        let puffed_uri = puffed_out_string(&uri, MAX_URI_LENGTH);
 
-    test_metadata
-        .create(&mut context, name, symbol, uri, None, 10, false)
-        .await
-        .unwrap();
+        test_metadata
+            .create(&mut context, name, symbol, uri, None, 10, false)
+            .await
+            .unwrap();
 
-    let metadata = test_metadata.get_data(&mut context).await;
+        let metadata = test_metadata.get_data(&mut context).await;
 
-    assert_eq!(metadata.data.name, puffed_name,);
-    assert_eq!(metadata.data.symbol, puffed_symbol);
-    assert_eq!(metadata.data.uri, puffed_uri);
-    assert_eq!(metadata.data.seller_fee_basis_points, 10);
-    assert_eq!(metadata.data.creators, None);
+        assert_eq!(metadata.data.name, puffed_name,);
+        assert_eq!(metadata.data.symbol, puffed_symbol);
+        assert_eq!(metadata.data.uri, puffed_uri);
+        assert_eq!(metadata.data.seller_fee_basis_points, 10);
+        assert_eq!(metadata.data.creators, None);
 
-    assert_eq!(metadata.primary_sale_happened, false);
-    assert_eq!(metadata.is_mutable, false);
-    assert_eq!(metadata.mint, test_metadata.mint.pubkey());
-    assert_eq!(metadata.update_authority, context.payer.pubkey());
-    assert_eq!(metadata.key, Key::MetadataV1);
-}
+        assert_eq!(metadata.primary_sale_happened, false);
+        assert_eq!(metadata.is_mutable, false);
+        assert_eq!(metadata.mint, test_metadata.mint.pubkey());
+        assert_eq!(metadata.update_authority, context.payer.pubkey());
+        assert_eq!(metadata.key, Key::MetadataV1);
+    }
 
-#[tokio::test]
-async fn fail_invalid_mint_authority() {
-    let mut context = program_test().start_with_context().await;
-    let test_metadata = Metadata::new();
-    let fake_mint_authority = Keypair::new();
-    let payer_pubkey = context.payer.pubkey();
+    #[tokio::test]
+    async fn fail_invalid_mint_authority() {
+        let mut context = program_test().start_with_context().await;
+        let test_metadata = Metadata::new();
+        let fake_mint_authority = Keypair::new();
+        let payer_pubkey = context.payer.pubkey();
 
-    create_mint(&mut context, &test_metadata.mint, &payer_pubkey, None)
-        .await
-        .unwrap();
-    create_token_account(
-        &mut context,
-        &test_metadata.token,
-        &test_metadata.mint.pubkey(),
-        &payer_pubkey,
-    )
-    .await
-    .unwrap();
-    mint_tokens(
-        &mut context,
-        &test_metadata.mint.pubkey(),
-        &test_metadata.token.pubkey(),
-        1,
-        &payer_pubkey,
-        None,
-    )
-    .await
-    .unwrap();
-
-    let ix = instruction::create_metadata_accounts(
-        id(),
-        test_metadata.pubkey.clone(),
-        test_metadata.mint.pubkey(),
-        fake_mint_authority.pubkey(),
-        context.payer.pubkey().clone(),
-        context.payer.pubkey().clone(),
-        "Test".to_string(),
-        "TST".to_string(),
-        "uri".to_string(),
-        None,
-        10,
-        false,
-        false,
-    );
-
-    let tx = Transaction::new_signed_with_payer(
-        &[ix],
-        Some(&context.payer.pubkey()),
-        &[&context.payer, &fake_mint_authority],
-        context.last_blockhash,
-    );
-
-    let result = context
-        .banks_client
-        .process_transaction(tx)
-        .await
-        .unwrap_err();
-
-    assert_custom_error!(result, MetadataError::InvalidMintAuthority);
-}
-
-#[tokio::test]
-async fn fail_invalid_metadata_pda() {
-    let mut context = program_test().start_with_context().await;
-    let mut test_metadata = Metadata::new();
-    test_metadata.pubkey = Pubkey::new_unique();
-
-    let result = test_metadata
-        .create(
+        create_mint(&mut context, &test_metadata.mint, &payer_pubkey, None)
+            .await
+            .unwrap();
+        create_token_account(
             &mut context,
+            &test_metadata.token,
+            &test_metadata.mint.pubkey(),
+            &payer_pubkey,
+        )
+        .await
+        .unwrap();
+        mint_tokens(
+            &mut context,
+            &test_metadata.mint.pubkey(),
+            &test_metadata.token.pubkey(),
+            1,
+            &payer_pubkey,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let ix = instruction::create_metadata_accounts(
+            id(),
+            test_metadata.pubkey.clone(),
+            test_metadata.mint.pubkey(),
+            fake_mint_authority.pubkey(),
+            context.payer.pubkey().clone(),
+            context.payer.pubkey().clone(),
             "Test".to_string(),
             "TST".to_string(),
             "uri".to_string(),
             None,
             10,
             false,
-        )
-        .await
-        .unwrap_err();
+            false,
+        );
 
-    assert_custom_error!(result, MetadataError::InvalidMetadataKey);
+        let tx = Transaction::new_signed_with_payer(
+            &[ix],
+            Some(&context.payer.pubkey()),
+            &[&context.payer, &fake_mint_authority],
+            context.last_blockhash,
+        );
+
+        let result = context
+            .banks_client
+            .process_transaction(tx)
+            .await
+            .unwrap_err();
+
+        assert_custom_error!(result, MetadataError::InvalidMintAuthority);
+    }
+
+    #[tokio::test]
+    async fn fail_invalid_metadata_pda() {
+        let mut context = program_test().start_with_context().await;
+        let mut test_metadata = Metadata::new();
+        test_metadata.pubkey = Pubkey::new_unique();
+
+        let result = test_metadata
+            .create(
+                &mut context,
+                "Test".to_string(),
+                "TST".to_string(),
+                "uri".to_string(),
+                None,
+                10,
+                false,
+            )
+            .await
+            .unwrap_err();
+
+        assert_custom_error!(result, MetadataError::InvalidMetadataKey);
+    }
 }

--- a/rust/token-metadata/program/tests/mint_new_edition_from_master_edition_via_token.rs
+++ b/rust/token-metadata/program/tests/mint_new_edition_from_master_edition_via_token.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "test-bpf")]
 mod utils;
 
 use metaplex_token_metadata::{error::MetadataError, id, instruction, state::Key};

--- a/rust/token-metadata/program/tests/mint_new_edition_from_master_edition_via_token.rs
+++ b/rust/token-metadata/program/tests/mint_new_edition_from_master_edition_via_token.rs
@@ -13,6 +13,8 @@ use metaplex_token_metadata::state::Key;
 use metaplex_token_metadata::{id, instruction};
 use utils::*;
 
+// NOTE: these tests depend on the token-vault program having been compiled
+// via (cd ../../token-vault/program/ && cargo build-bpf)
 mod mint_new_edition_from_master_edition_via_token {
     use super::*;
     #[tokio::test]

--- a/rust/token-metadata/program/tests/mint_new_edition_from_master_edition_via_token.rs
+++ b/rust/token-metadata/program/tests/mint_new_edition_from_master_edition_via_token.rs
@@ -13,180 +13,183 @@ use metaplex_token_metadata::state::Key;
 use metaplex_token_metadata::{id, instruction};
 use utils::*;
 
-#[tokio::test]
-async fn success() {
-    let mut context = program_test().start_with_context().await;
-    let test_metadata = Metadata::new();
-    let test_master_edition = MasterEditionV2::new(&test_metadata);
-    let test_edition_marker = EditionMarker::new(&test_metadata, &test_master_edition, 1);
+mod mint_new_edition_from_master_edition_via_token {
+    use super::*;
+    #[tokio::test]
+    async fn success() {
+        let mut context = program_test().start_with_context().await;
+        let test_metadata = Metadata::new();
+        let test_master_edition = MasterEditionV2::new(&test_metadata);
+        let test_edition_marker = EditionMarker::new(&test_metadata, &test_master_edition, 1);
 
-    test_metadata
-        .create(
+        test_metadata
+            .create(
+                &mut context,
+                "Test".to_string(),
+                "TST".to_string(),
+                "uri".to_string(),
+                None,
+                10,
+                false,
+            )
+            .await
+            .unwrap();
+
+        test_master_edition
+            .create(&mut context, Some(10))
+            .await
+            .unwrap();
+
+        test_edition_marker.create(&mut context).await.unwrap();
+
+        let edition_marker = test_edition_marker.get_data(&mut context).await;
+
+        assert_eq!(edition_marker.ledger[0], 64);
+        assert_eq!(edition_marker.key, Key::EditionMarker);
+    }
+
+    #[tokio::test]
+    async fn fail_invalid_token_program() {
+        let mut context = program_test().start_with_context().await;
+        let test_metadata = Metadata::new();
+        let test_master_edition = MasterEditionV2::new(&test_metadata);
+        let test_edition_marker = EditionMarker::new(&test_metadata, &test_master_edition, 1);
+
+        test_metadata
+            .create(
+                &mut context,
+                "Test".to_string(),
+                "TST".to_string(),
+                "uri".to_string(),
+                None,
+                10,
+                false,
+            )
+            .await
+            .unwrap();
+
+        test_master_edition
+            .create(&mut context, Some(10))
+            .await
+            .unwrap();
+
+        let result = test_edition_marker
+            .create_with_invalid_token_program(&mut context)
+            .await
+            .unwrap_err();
+        assert_custom_error!(result, MetadataError::InvalidTokenProgram);
+    }
+
+    #[tokio::test]
+    async fn fail_invalid_mint() {
+        let mut context = program_test().start_with_context().await;
+        let test_metadata = Metadata::new();
+        let test_master_edition = MasterEditionV2::new(&test_metadata);
+        let test_edition_marker = EditionMarker::new(&test_metadata, &test_master_edition, 1);
+        let fake_mint = Keypair::new();
+        let fake_account = Keypair::new();
+        let payer_pubkey = context.payer.pubkey();
+
+        test_metadata
+            .create(
+                &mut context,
+                "Test".to_string(),
+                "TST".to_string(),
+                "uri".to_string(),
+                None,
+                10,
+                false,
+            )
+            .await
+            .unwrap();
+
+        test_master_edition
+            .create(&mut context, Some(10))
+            .await
+            .unwrap();
+
+        create_mint(&mut context, &fake_mint, &payer_pubkey, None)
+            .await
+            .unwrap();
+
+        create_token_account(
             &mut context,
-            "Test".to_string(),
-            "TST".to_string(),
-            "uri".to_string(),
-            None,
-            10,
-            false,
+            &fake_account,
+            &fake_mint.pubkey(),
+            &payer_pubkey,
         )
         .await
         .unwrap();
 
-    test_master_edition
-        .create(&mut context, Some(10))
-        .await
-        .unwrap();
-
-    test_edition_marker.create(&mut context).await.unwrap();
-
-    let edition_marker = test_edition_marker.get_data(&mut context).await;
-
-    assert_eq!(edition_marker.ledger[0], 64);
-    assert_eq!(edition_marker.key, Key::EditionMarker);
-}
-
-#[tokio::test]
-async fn fail_invalid_token_program() {
-    let mut context = program_test().start_with_context().await;
-    let test_metadata = Metadata::new();
-    let test_master_edition = MasterEditionV2::new(&test_metadata);
-    let test_edition_marker = EditionMarker::new(&test_metadata, &test_master_edition, 1);
-
-    test_metadata
-        .create(
+        mint_tokens(
             &mut context,
-            "Test".to_string(),
-            "TST".to_string(),
-            "uri".to_string(),
+            &fake_mint.pubkey(),
+            &fake_account.pubkey(),
+            1,
+            &payer_pubkey,
             None,
-            10,
-            false,
         )
         .await
         .unwrap();
 
-    test_master_edition
-        .create(&mut context, Some(10))
-        .await
-        .unwrap();
+        let tx = Transaction::new_signed_with_payer(
+            &[instruction::mint_new_edition_from_master_edition_via_token(
+                id(),
+                test_edition_marker.new_metadata_pubkey,
+                test_edition_marker.new_edition_pubkey,
+                test_edition_marker.master_edition_pubkey,
+                fake_mint.pubkey(),
+                context.payer.pubkey(),
+                context.payer.pubkey(),
+                context.payer.pubkey(),
+                fake_account.pubkey(),
+                context.payer.pubkey(),
+                test_edition_marker.metadata_pubkey,
+                test_edition_marker.metadata_mint_pubkey,
+                test_edition_marker.edition,
+            )],
+            Some(&context.payer.pubkey()),
+            &[&context.payer, &context.payer, &context.payer],
+            context.last_blockhash,
+        );
 
-    let result = test_edition_marker
-        .create_with_invalid_token_program(&mut context)
-        .await
-        .unwrap_err();
-    assert_custom_error!(result, MetadataError::InvalidTokenProgram);
-}
+        let result = context
+            .banks_client
+            .process_transaction(tx)
+            .await
+            .unwrap_err();
 
-#[tokio::test]
-async fn fail_invalid_mint() {
-    let mut context = program_test().start_with_context().await;
-    let test_metadata = Metadata::new();
-    let test_master_edition = MasterEditionV2::new(&test_metadata);
-    let test_edition_marker = EditionMarker::new(&test_metadata, &test_master_edition, 1);
-    let fake_mint = Keypair::new();
-    let fake_account = Keypair::new();
-    let payer_pubkey = context.payer.pubkey();
+        assert_custom_error!(result, MetadataError::TokenAccountMintMismatchV2);
+    }
 
-    test_metadata
-        .create(
-            &mut context,
-            "Test".to_string(),
-            "TST".to_string(),
-            "uri".to_string(),
-            None,
-            10,
-            false,
-        )
-        .await
-        .unwrap();
+    #[tokio::test]
+    async fn fail_edition_already_initialized() {
+        let mut context = program_test().start_with_context().await;
+        let test_metadata = Metadata::new();
+        let test_master_edition = MasterEditionV2::new(&test_metadata);
+        let test_edition_marker = EditionMarker::new(&test_metadata, &test_master_edition, 1);
+        let test_edition_marker1 = EditionMarker::new(&test_metadata, &test_master_edition, 1);
 
-    test_master_edition
-        .create(&mut context, Some(10))
-        .await
-        .unwrap();
+        test_metadata
+            .create(
+                &mut context,
+                "Test".to_string(),
+                "TST".to_string(),
+                "uri".to_string(),
+                None,
+                10,
+                false,
+            )
+            .await
+            .unwrap();
 
-    create_mint(&mut context, &fake_mint, &payer_pubkey, None)
-        .await
-        .unwrap();
+        test_master_edition
+            .create(&mut context, Some(10))
+            .await
+            .unwrap();
 
-    create_token_account(
-        &mut context,
-        &fake_account,
-        &fake_mint.pubkey(),
-        &payer_pubkey,
-    )
-    .await
-    .unwrap();
-
-    mint_tokens(
-        &mut context,
-        &fake_mint.pubkey(),
-        &fake_account.pubkey(),
-        1,
-        &payer_pubkey,
-        None,
-    )
-    .await
-    .unwrap();
-
-    let tx = Transaction::new_signed_with_payer(
-        &[instruction::mint_new_edition_from_master_edition_via_token(
-            id(),
-            test_edition_marker.new_metadata_pubkey,
-            test_edition_marker.new_edition_pubkey,
-            test_edition_marker.master_edition_pubkey,
-            fake_mint.pubkey(),
-            context.payer.pubkey(),
-            context.payer.pubkey(),
-            context.payer.pubkey(),
-            fake_account.pubkey(),
-            context.payer.pubkey(),
-            test_edition_marker.metadata_pubkey,
-            test_edition_marker.metadata_mint_pubkey,
-            test_edition_marker.edition,
-        )],
-        Some(&context.payer.pubkey()),
-        &[&context.payer, &context.payer, &context.payer],
-        context.last_blockhash,
-    );
-
-    let result = context
-        .banks_client
-        .process_transaction(tx)
-        .await
-        .unwrap_err();
-
-    assert_custom_error!(result, MetadataError::TokenAccountMintMismatchV2);
-}
-
-#[tokio::test]
-async fn fail_edition_already_initialized() {
-    let mut context = program_test().start_with_context().await;
-    let test_metadata = Metadata::new();
-    let test_master_edition = MasterEditionV2::new(&test_metadata);
-    let test_edition_marker = EditionMarker::new(&test_metadata, &test_master_edition, 1);
-    let test_edition_marker1 = EditionMarker::new(&test_metadata, &test_master_edition, 1);
-
-    test_metadata
-        .create(
-            &mut context,
-            "Test".to_string(),
-            "TST".to_string(),
-            "uri".to_string(),
-            None,
-            10,
-            false,
-        )
-        .await
-        .unwrap();
-
-    test_master_edition
-        .create(&mut context, Some(10))
-        .await
-        .unwrap();
-
-    test_edition_marker.create(&mut context).await.unwrap();
-    let result = test_edition_marker1.create(&mut context).await.unwrap_err();
-    assert_custom_error!(result, MetadataError::AlreadyInitialized);
+        test_edition_marker.create(&mut context).await.unwrap();
+        let result = test_edition_marker1.create(&mut context).await.unwrap_err();
+        assert_custom_error!(result, MetadataError::AlreadyInitialized);
+    }
 }

--- a/rust/token-metadata/program/tests/mint_new_edition_from_master_edition_via_token.rs
+++ b/rust/token-metadata/program/tests/mint_new_edition_from_master_edition_via_token.rs
@@ -1,5 +1,6 @@
 mod utils;
 
+use metaplex_token_metadata::{error::MetadataError, id, instruction, state::Key};
 use num_traits::FromPrimitive;
 use solana_program_test::*;
 use solana_sdk::{
@@ -8,9 +9,6 @@ use solana_sdk::{
     transaction::{Transaction, TransactionError},
     transport::TransportError,
 };
-use metaplex_token_metadata::error::MetadataError;
-use metaplex_token_metadata::state::Key;
-use metaplex_token_metadata::{id, instruction};
 use utils::*;
 
 // NOTE: these tests depend on the token-vault program having been compiled

--- a/rust/token-metadata/program/tests/mint_new_edition_from_master_edition_via_vault_proxy.rs
+++ b/rust/token-metadata/program/tests/mint_new_edition_from_master_edition_via_vault_proxy.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "test-bpf")]
 mod utils;
 
 use metaplex_token_metadata::{error::MetadataError, id, instruction, state::Key};

--- a/rust/token-metadata/program/tests/mint_new_edition_from_master_edition_via_vault_proxy.rs
+++ b/rust/token-metadata/program/tests/mint_new_edition_from_master_edition_via_vault_proxy.rs
@@ -15,6 +15,8 @@ use metaplex_token_metadata::{id, instruction};
 use metaplex_token_vault::state::PREFIX;
 use utils::*;
 
+// NOTE: these tests depend on the token-vault program having been compiled
+// via (cd ../../token-vault/program/ && cargo build-bpf)
 mod mint_new_edition_from_master_edition_via_vault_proxy {
     use super::*;
     #[tokio::test]

--- a/rust/token-metadata/program/tests/mint_new_edition_from_master_edition_via_vault_proxy.rs
+++ b/rust/token-metadata/program/tests/mint_new_edition_from_master_edition_via_vault_proxy.rs
@@ -15,394 +15,397 @@ use metaplex_token_metadata::{id, instruction};
 use metaplex_token_vault::state::PREFIX;
 use utils::*;
 
-#[tokio::test]
-async fn success() {
-    let mut program_test = program_test();
-    program_test.add_program("metaplex_token_vault", metaplex_token_vault::id(), None);
-    let mut context = program_test.start_with_context().await;
+mod mint_new_edition_from_master_edition_via_vault_proxy {
+    use super::*;
+    #[tokio::test]
+    async fn success() {
+        let mut program_test = program_test();
+        program_test.add_program("metaplex_token_vault", metaplex_token_vault::id(), None);
+        let mut context = program_test.start_with_context().await;
 
-    let test_metadata = Metadata::new();
-    let test_master_edition = MasterEditionV2::new(&test_metadata);
-    let test_external_price = ExternalPrice::new();
-    let test_vault = Vault::new();
-    let test_edition_marker = EditionMarker::new(&test_metadata, &test_master_edition, 10);
+        let test_metadata = Metadata::new();
+        let test_master_edition = MasterEditionV2::new(&test_metadata);
+        let test_external_price = ExternalPrice::new();
+        let test_vault = Vault::new();
+        let test_edition_marker = EditionMarker::new(&test_metadata, &test_master_edition, 10);
 
-    test_metadata
-        .create(
+        test_metadata
+            .create(
+                &mut context,
+                "Test".to_string(),
+                "TST".to_string(),
+                "uri".to_string(),
+                None,
+                10,
+                false,
+            )
+            .await
+            .unwrap();
+
+        test_master_edition
+            .create(&mut context, Some(10))
+            .await
+            .unwrap();
+
+        test_external_price.create(&mut context).await.unwrap();
+        test_external_price
+            .update(
+                &mut context,
+                1,
+                &test_external_price.price_mint.pubkey(),
+                true,
+            )
+            .await
+            .unwrap();
+
+        test_vault
+            .create(&mut context, &test_external_price)
+            .await
+            .unwrap();
+
+        let (safety_deposit_box, store) = test_vault
+            .add_token_to_inactive_vault(&mut context, 1, &test_metadata)
+            .await
+            .unwrap();
+
+        test_vault.activate(&mut context, 1).await.unwrap();
+
+        test_vault
+            .combine(&mut context, &test_external_price)
+            .await
+            .unwrap();
+
+        test_edition_marker
+            .create_via_vault(&mut context, &test_vault, &safety_deposit_box, &store)
+            .await
+            .unwrap();
+
+        let edition_marker = test_edition_marker.get_data(&mut context).await;
+
+        assert_eq!(edition_marker.ledger[1], 32);
+        assert_eq!(edition_marker.key, Key::EditionMarker);
+    }
+
+    #[tokio::test]
+    async fn fail_invalid_store_owner_pda() {
+        let mut program_test = program_test();
+        program_test.add_program("metaplex_token_vault", metaplex_token_vault::id(), None);
+        let mut context = program_test.start_with_context().await;
+
+        let test_metadata = Metadata::new();
+        let test_master_edition = MasterEditionV2::new(&test_metadata);
+        let test_external_price = ExternalPrice::new();
+        let test_vault = Vault::new();
+        let test_edition_marker = EditionMarker::new(&test_metadata, &test_master_edition, 10);
+        let fake_store = Keypair::new();
+        let payer_pubkey = context.payer.pubkey();
+
+        test_metadata
+            .create(
+                &mut context,
+                "Test".to_string(),
+                "TST".to_string(),
+                "uri".to_string(),
+                None,
+                10,
+                false,
+            )
+            .await
+            .unwrap();
+
+        test_master_edition
+            .create(&mut context, Some(10))
+            .await
+            .unwrap();
+
+        test_external_price.create(&mut context).await.unwrap();
+        test_external_price
+            .update(
+                &mut context,
+                1,
+                &test_external_price.price_mint.pubkey(),
+                true,
+            )
+            .await
+            .unwrap();
+
+        test_vault
+            .create(&mut context, &test_external_price)
+            .await
+            .unwrap();
+
+        let (safety_deposit_box, _) = test_vault
+            .add_token_to_inactive_vault(&mut context, 1, &test_metadata)
+            .await
+            .unwrap();
+
+        test_vault.activate(&mut context, 1).await.unwrap();
+
+        test_vault
+            .combine(&mut context, &test_external_price)
+            .await
+            .unwrap();
+
+        create_token_account(
             &mut context,
-            "Test".to_string(),
-            "TST".to_string(),
-            "uri".to_string(),
-            None,
-            10,
-            false,
+            &fake_store,
+            &test_vault.mint.pubkey(),
+            &payer_pubkey,
         )
         .await
         .unwrap();
+        let tx = Transaction::new_signed_with_payer(
+            &[
+                instruction::mint_edition_from_master_edition_via_vault_proxy(
+                    id(),
+                    test_edition_marker.new_metadata_pubkey,
+                    test_edition_marker.new_edition_pubkey,
+                    test_edition_marker.master_edition_pubkey,
+                    test_edition_marker.mint.pubkey(),
+                    test_edition_marker.pubkey,
+                    context.payer.pubkey(),
+                    context.payer.pubkey(),
+                    context.payer.pubkey(),
+                    fake_store.pubkey(),
+                    safety_deposit_box,
+                    test_vault.keypair.pubkey(),
+                    context.payer.pubkey(),
+                    test_edition_marker.metadata_pubkey,
+                    spl_token::id(),
+                    metaplex_token_vault::id(),
+                    test_edition_marker.edition,
+                ),
+            ],
+            Some(&context.payer.pubkey()),
+            &[&context.payer, &context.payer],
+            context.last_blockhash,
+        );
 
-    test_master_edition
-        .create(&mut context, Some(10))
-        .await
-        .unwrap();
+        let result = context
+            .banks_client
+            .process_transaction(tx)
+            .await
+            .unwrap_err();
 
-    test_external_price.create(&mut context).await.unwrap();
-    test_external_price
-        .update(
-            &mut context,
-            1,
-            &test_external_price.price_mint.pubkey(),
-            true,
-        )
-        .await
-        .unwrap();
+        assert_custom_error!(result, MetadataError::InvalidOwner);
+    }
 
-    test_vault
-        .create(&mut context, &test_external_price)
-        .await
-        .unwrap();
+    #[tokio::test]
+    async fn fail_invalid_vault_authority() {
+        let mut program_test = program_test();
+        program_test.add_program("metaplex_token_vault", metaplex_token_vault::id(), None);
+        let mut context = program_test.start_with_context().await;
 
-    let (safety_deposit_box, store) = test_vault
-        .add_token_to_inactive_vault(&mut context, 1, &test_metadata)
-        .await
-        .unwrap();
+        let test_metadata = Metadata::new();
+        let test_master_edition = MasterEditionV2::new(&test_metadata);
+        let test_external_price = ExternalPrice::new();
+        let test_vault = Vault::new();
+        let test_edition_marker = EditionMarker::new(&test_metadata, &test_master_edition, 10);
+        let fake_vault_authority = Keypair::new();
 
-    test_vault.activate(&mut context, 1).await.unwrap();
+        test_metadata
+            .create(
+                &mut context,
+                "Test".to_string(),
+                "TST".to_string(),
+                "uri".to_string(),
+                None,
+                10,
+                false,
+            )
+            .await
+            .unwrap();
 
-    test_vault
-        .combine(&mut context, &test_external_price)
-        .await
-        .unwrap();
+        test_master_edition
+            .create(&mut context, Some(10))
+            .await
+            .unwrap();
 
-    test_edition_marker
-        .create_via_vault(&mut context, &test_vault, &safety_deposit_box, &store)
-        .await
-        .unwrap();
+        test_external_price.create(&mut context).await.unwrap();
+        test_external_price
+            .update(
+                &mut context,
+                1,
+                &test_external_price.price_mint.pubkey(),
+                true,
+            )
+            .await
+            .unwrap();
 
-    let edition_marker = test_edition_marker.get_data(&mut context).await;
+        test_vault
+            .create(&mut context, &test_external_price)
+            .await
+            .unwrap();
 
-    assert_eq!(edition_marker.ledger[1], 32);
-    assert_eq!(edition_marker.key, Key::EditionMarker);
-}
+        let (safety_deposit_box, store) = test_vault
+            .add_token_to_inactive_vault(&mut context, 1, &test_metadata)
+            .await
+            .unwrap();
 
-#[tokio::test]
-async fn fail_invalid_store_owner_pda() {
-    let mut program_test = program_test();
-    program_test.add_program("metaplex_token_vault", metaplex_token_vault::id(), None);
-    let mut context = program_test.start_with_context().await;
+        test_vault.activate(&mut context, 1).await.unwrap();
 
-    let test_metadata = Metadata::new();
-    let test_master_edition = MasterEditionV2::new(&test_metadata);
-    let test_external_price = ExternalPrice::new();
-    let test_vault = Vault::new();
-    let test_edition_marker = EditionMarker::new(&test_metadata, &test_master_edition, 10);
-    let fake_store = Keypair::new();
-    let payer_pubkey = context.payer.pubkey();
+        test_vault
+            .combine(&mut context, &test_external_price)
+            .await
+            .unwrap();
 
-    test_metadata
-        .create(
-            &mut context,
-            "Test".to_string(),
-            "TST".to_string(),
-            "uri".to_string(),
-            None,
-            10,
-            false,
-        )
-        .await
-        .unwrap();
+        let tx = Transaction::new_signed_with_payer(
+            &[
+                instruction::mint_edition_from_master_edition_via_vault_proxy(
+                    id(),
+                    test_edition_marker.new_metadata_pubkey,
+                    test_edition_marker.new_edition_pubkey,
+                    test_edition_marker.master_edition_pubkey,
+                    test_edition_marker.mint.pubkey(),
+                    test_edition_marker.pubkey,
+                    context.payer.pubkey(),
+                    context.payer.pubkey(),
+                    fake_vault_authority.pubkey(),
+                    store,
+                    safety_deposit_box,
+                    test_vault.keypair.pubkey(),
+                    context.payer.pubkey(),
+                    test_edition_marker.metadata_pubkey,
+                    spl_token::id(),
+                    metaplex_token_vault::id(),
+                    test_edition_marker.edition,
+                ),
+            ],
+            Some(&context.payer.pubkey()),
+            &[&context.payer, &context.payer, &fake_vault_authority],
+            context.last_blockhash,
+        );
 
-    test_master_edition
-        .create(&mut context, Some(10))
-        .await
-        .unwrap();
+        let result = context
+            .banks_client
+            .process_transaction(tx)
+            .await
+            .unwrap_err();
 
-    test_external_price.create(&mut context).await.unwrap();
-    test_external_price
-        .update(
-            &mut context,
-            1,
-            &test_external_price.price_mint.pubkey(),
-            true,
-        )
-        .await
-        .unwrap();
+        assert_custom_error!(
+            result,
+            metaplex_token_vault::error::VaultError::AuthorityDoesNotMatch
+        );
+    }
 
-    test_vault
-        .create(&mut context, &test_external_price)
-        .await
-        .unwrap();
+    #[tokio::test]
+    async fn fail_store_account_mismatch() {
+        let mut program_test = program_test();
+        program_test.add_program("metaplex_token_vault", metaplex_token_vault::id(), None);
+        let mut context = program_test.start_with_context().await;
 
-    let (safety_deposit_box, _) = test_vault
-        .add_token_to_inactive_vault(&mut context, 1, &test_metadata)
-        .await
-        .unwrap();
+        let test_metadata = Metadata::new();
+        let test_master_edition = MasterEditionV2::new(&test_metadata);
+        let test_external_price = ExternalPrice::new();
+        let test_vault = Vault::new();
 
-    test_vault.activate(&mut context, 1).await.unwrap();
+        let test_edition_marker = EditionMarker::new(&test_metadata, &test_master_edition, 10);
 
-    test_vault
-        .combine(&mut context, &test_external_price)
-        .await
-        .unwrap();
+        // TEST VAULT
+        test_metadata
+            .create(
+                &mut context,
+                "Test".to_string(),
+                "TST".to_string(),
+                "uri".to_string(),
+                None,
+                10,
+                false,
+            )
+            .await
+            .unwrap();
 
-    create_token_account(
-        &mut context,
-        &fake_store,
-        &test_vault.mint.pubkey(),
-        &payer_pubkey,
-    )
-    .await
-    .unwrap();
-    let tx = Transaction::new_signed_with_payer(
-        &[
-            instruction::mint_edition_from_master_edition_via_vault_proxy(
-                id(),
-                test_edition_marker.new_metadata_pubkey,
-                test_edition_marker.new_edition_pubkey,
-                test_edition_marker.master_edition_pubkey,
-                test_edition_marker.mint.pubkey(),
-                test_edition_marker.pubkey,
-                context.payer.pubkey(),
-                context.payer.pubkey(),
-                context.payer.pubkey(),
-                fake_store.pubkey(),
-                safety_deposit_box,
-                test_vault.keypair.pubkey(),
-                context.payer.pubkey(),
-                test_edition_marker.metadata_pubkey,
-                spl_token::id(),
-                metaplex_token_vault::id(),
-                test_edition_marker.edition,
-            ),
-        ],
-        Some(&context.payer.pubkey()),
-        &[&context.payer, &context.payer],
-        context.last_blockhash,
-    );
+        test_master_edition
+            .create(&mut context, Some(10))
+            .await
+            .unwrap();
 
-    let result = context
-        .banks_client
-        .process_transaction(tx)
-        .await
-        .unwrap_err();
+        test_external_price.create(&mut context).await.unwrap();
+        test_external_price
+            .update(
+                &mut context,
+                1,
+                &test_external_price.price_mint.pubkey(),
+                true,
+            )
+            .await
+            .unwrap();
 
-    assert_custom_error!(result, MetadataError::InvalidOwner);
-}
+        test_vault
+            .create(&mut context, &test_external_price)
+            .await
+            .unwrap();
 
-#[tokio::test]
-async fn fail_invalid_vault_authority() {
-    let mut program_test = program_test();
-    program_test.add_program("metaplex_token_vault", metaplex_token_vault::id(), None);
-    let mut context = program_test.start_with_context().await;
+        let (safety_deposit_box, _) = test_vault
+            .add_token_to_inactive_vault(&mut context, 1, &test_metadata)
+            .await
+            .unwrap();
 
-    let test_metadata = Metadata::new();
-    let test_master_edition = MasterEditionV2::new(&test_metadata);
-    let test_external_price = ExternalPrice::new();
-    let test_vault = Vault::new();
-    let test_edition_marker = EditionMarker::new(&test_metadata, &test_master_edition, 10);
-    let fake_vault_authority = Keypair::new();
+        test_vault.activate(&mut context, 1).await.unwrap();
 
-    test_metadata
-        .create(
-            &mut context,
-            "Test".to_string(),
-            "TST".to_string(),
-            "uri".to_string(),
-            None,
-            10,
-            false,
-        )
-        .await
-        .unwrap();
+        test_vault
+            .combine(&mut context, &test_external_price)
+            .await
+            .unwrap();
 
-    test_master_edition
-        .create(&mut context, Some(10))
-        .await
-        .unwrap();
+        // Generate fake store
+        let store = Keypair::new();
+        let token_mint_pubkey = test_metadata.mint.pubkey();
+        let metaplex_token_vault_id = metaplex_token_vault::id();
+        let vault_pubkey = test_vault.keypair.pubkey();
 
-    test_external_price.create(&mut context).await.unwrap();
-    test_external_price
-        .update(
-            &mut context,
-            1,
-            &test_external_price.price_mint.pubkey(),
-            true,
-        )
-        .await
-        .unwrap();
+        let seeds = &[
+            PREFIX.as_bytes(),
+            &vault_pubkey.as_ref(),
+            &token_mint_pubkey.as_ref(),
+        ];
+        let (_, _) = Pubkey::find_program_address(seeds, &metaplex_token_vault_id);
+        let seeds = &[
+            PREFIX.as_bytes(),
+            &metaplex_token_vault_id.as_ref(),
+            &vault_pubkey.as_ref(),
+        ];
+        let (authority, _) = Pubkey::find_program_address(seeds, &metaplex_token_vault_id);
+        create_token_account(&mut context, &store, &token_mint_pubkey, &authority)
+            .await
+            .unwrap();
 
-    test_vault
-        .create(&mut context, &test_external_price)
-        .await
-        .unwrap();
+        let tx = Transaction::new_signed_with_payer(
+            &[
+                instruction::mint_edition_from_master_edition_via_vault_proxy(
+                    id(),
+                    test_edition_marker.new_metadata_pubkey,
+                    test_edition_marker.new_edition_pubkey,
+                    test_edition_marker.master_edition_pubkey,
+                    test_edition_marker.mint.pubkey(),
+                    test_edition_marker.pubkey,
+                    context.payer.pubkey(),
+                    context.payer.pubkey(),
+                    context.payer.pubkey(),
+                    store.pubkey(),
+                    safety_deposit_box,
+                    test_vault.keypair.pubkey(),
+                    context.payer.pubkey(),
+                    test_edition_marker.metadata_pubkey,
+                    spl_token::id(),
+                    metaplex_token_vault::id(),
+                    test_edition_marker.edition,
+                ),
+            ],
+            Some(&context.payer.pubkey()),
+            &[&context.payer, &context.payer],
+            context.last_blockhash,
+        );
 
-    let (safety_deposit_box, store) = test_vault
-        .add_token_to_inactive_vault(&mut context, 1, &test_metadata)
-        .await
-        .unwrap();
+        let result = context
+            .banks_client
+            .process_transaction(tx)
+            .await
+            .unwrap_err();
 
-    test_vault.activate(&mut context, 1).await.unwrap();
-
-    test_vault
-        .combine(&mut context, &test_external_price)
-        .await
-        .unwrap();
-
-    let tx = Transaction::new_signed_with_payer(
-        &[
-            instruction::mint_edition_from_master_edition_via_vault_proxy(
-                id(),
-                test_edition_marker.new_metadata_pubkey,
-                test_edition_marker.new_edition_pubkey,
-                test_edition_marker.master_edition_pubkey,
-                test_edition_marker.mint.pubkey(),
-                test_edition_marker.pubkey,
-                context.payer.pubkey(),
-                context.payer.pubkey(),
-                fake_vault_authority.pubkey(),
-                store,
-                safety_deposit_box,
-                test_vault.keypair.pubkey(),
-                context.payer.pubkey(),
-                test_edition_marker.metadata_pubkey,
-                spl_token::id(),
-                metaplex_token_vault::id(),
-                test_edition_marker.edition,
-            ),
-        ],
-        Some(&context.payer.pubkey()),
-        &[&context.payer, &context.payer, &fake_vault_authority],
-        context.last_blockhash,
-    );
-
-    let result = context
-        .banks_client
-        .process_transaction(tx)
-        .await
-        .unwrap_err();
-
-    assert_custom_error!(
-        result,
-        metaplex_token_vault::error::VaultError::AuthorityDoesNotMatch
-    );
-}
-
-#[tokio::test]
-async fn fail_store_account_mismatch() {
-    let mut program_test = program_test();
-    program_test.add_program("metaplex_token_vault", metaplex_token_vault::id(), None);
-    let mut context = program_test.start_with_context().await;
-
-    let test_metadata = Metadata::new();
-    let test_master_edition = MasterEditionV2::new(&test_metadata);
-    let test_external_price = ExternalPrice::new();
-    let test_vault = Vault::new();
-
-    let test_edition_marker = EditionMarker::new(&test_metadata, &test_master_edition, 10);
-
-    // TEST VAULT
-    test_metadata
-        .create(
-            &mut context,
-            "Test".to_string(),
-            "TST".to_string(),
-            "uri".to_string(),
-            None,
-            10,
-            false,
-        )
-        .await
-        .unwrap();
-
-    test_master_edition
-        .create(&mut context, Some(10))
-        .await
-        .unwrap();
-
-    test_external_price.create(&mut context).await.unwrap();
-    test_external_price
-        .update(
-            &mut context,
-            1,
-            &test_external_price.price_mint.pubkey(),
-            true,
-        )
-        .await
-        .unwrap();
-
-    test_vault
-        .create(&mut context, &test_external_price)
-        .await
-        .unwrap();
-
-    let (safety_deposit_box, _) = test_vault
-        .add_token_to_inactive_vault(&mut context, 1, &test_metadata)
-        .await
-        .unwrap();
-
-    test_vault.activate(&mut context, 1).await.unwrap();
-
-    test_vault
-        .combine(&mut context, &test_external_price)
-        .await
-        .unwrap();
-
-    // Generate fake store
-    let store = Keypair::new();
-    let token_mint_pubkey = test_metadata.mint.pubkey();
-    let metaplex_token_vault_id = metaplex_token_vault::id();
-    let vault_pubkey = test_vault.keypair.pubkey();
-
-    let seeds = &[
-        PREFIX.as_bytes(),
-        &vault_pubkey.as_ref(),
-        &token_mint_pubkey.as_ref(),
-    ];
-    let (_, _) = Pubkey::find_program_address(seeds, &metaplex_token_vault_id);
-    let seeds = &[
-        PREFIX.as_bytes(),
-        &metaplex_token_vault_id.as_ref(),
-        &vault_pubkey.as_ref(),
-    ];
-    let (authority, _) = Pubkey::find_program_address(seeds, &metaplex_token_vault_id);
-    create_token_account(&mut context, &store, &token_mint_pubkey, &authority)
-        .await
-        .unwrap();
-
-    let tx = Transaction::new_signed_with_payer(
-        &[
-            instruction::mint_edition_from_master_edition_via_vault_proxy(
-                id(),
-                test_edition_marker.new_metadata_pubkey,
-                test_edition_marker.new_edition_pubkey,
-                test_edition_marker.master_edition_pubkey,
-                test_edition_marker.mint.pubkey(),
-                test_edition_marker.pubkey,
-                context.payer.pubkey(),
-                context.payer.pubkey(),
-                context.payer.pubkey(),
-                store.pubkey(),
-                safety_deposit_box,
-                test_vault.keypair.pubkey(),
-                context.payer.pubkey(),
-                test_edition_marker.metadata_pubkey,
-                spl_token::id(),
-                metaplex_token_vault::id(),
-                test_edition_marker.edition,
-            ),
-        ],
-        Some(&context.payer.pubkey()),
-        &[&context.payer, &context.payer],
-        context.last_blockhash,
-    );
-
-    let result = context
-        .banks_client
-        .process_transaction(tx)
-        .await
-        .unwrap_err();
-
-    assert_custom_error!(
-        result,
-        metaplex_token_vault::error::VaultError::StoreDoesNotMatchSafetyDepositBox
-    );
+        assert_custom_error!(
+            result,
+            metaplex_token_vault::error::VaultError::StoreDoesNotMatchSafetyDepositBox
+        );
+    }
 }

--- a/rust/token-metadata/program/tests/mint_new_edition_from_master_edition_via_vault_proxy.rs
+++ b/rust/token-metadata/program/tests/mint_new_edition_from_master_edition_via_vault_proxy.rs
@@ -1,5 +1,7 @@
 mod utils;
 
+use metaplex_token_metadata::{error::MetadataError, id, instruction, state::Key};
+use metaplex_token_vault::state::PREFIX;
 use num_traits::FromPrimitive;
 use solana_program_test::*;
 use solana_sdk::{
@@ -9,10 +11,6 @@ use solana_sdk::{
     transaction::{Transaction, TransactionError},
     transport::TransportError,
 };
-use metaplex_token_metadata::error::MetadataError;
-use metaplex_token_metadata::state::Key;
-use metaplex_token_metadata::{id, instruction};
-use metaplex_token_vault::state::PREFIX;
 use utils::*;
 
 // NOTE: these tests depend on the token-vault program having been compiled

--- a/rust/token-metadata/program/tests/update_metadata_account.rs
+++ b/rust/token-metadata/program/tests/update_metadata_account.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "test-bpf")]
 mod utils;
 
 use metaplex_token_metadata::{

--- a/rust/token-metadata/program/tests/update_metadata_account.rs
+++ b/rust/token-metadata/program/tests/update_metadata_account.rs
@@ -13,89 +13,92 @@ use metaplex_token_metadata::state::Key;
 use metaplex_token_metadata::{id, instruction};
 use utils::*;
 
-#[tokio::test]
-async fn success() {
-    let mut context = program_test().start_with_context().await;
-    let test_metadata = Metadata::new();
+mod update_metadata_account {
+    use super::*;
+    #[tokio::test]
+    async fn success() {
+        let mut context = program_test().start_with_context().await;
+        let test_metadata = Metadata::new();
 
-    test_metadata
-        .create(
-            &mut context,
-            "Test".to_string(),
-            "TST".to_string(),
-            "uri".to_string(),
-            None,
-            10,
-            true,
-        )
-        .await
-        .unwrap();
+        test_metadata
+            .create(
+                &mut context,
+                "Test".to_string(),
+                "TST".to_string(),
+                "uri".to_string(),
+                None,
+                10,
+                true,
+            )
+            .await
+            .unwrap();
 
-    test_metadata
-        .update(
-            &mut context,
-            "Cool".to_string(),
-            "TST".to_string(),
-            "uri".to_string(),
-            None,
-            10,
-        )
-        .await
-        .unwrap();
+        test_metadata
+            .update(
+                &mut context,
+                "Cool".to_string(),
+                "TST".to_string(),
+                "uri".to_string(),
+                None,
+                10,
+            )
+            .await
+            .unwrap();
 
-    let metadata = test_metadata.get_data(&mut context).await;
+        let metadata = test_metadata.get_data(&mut context).await;
 
-    assert_eq!(metadata.data.name, "Cool");
-    assert_eq!(metadata.data.symbol, "TST");
-    assert_eq!(metadata.data.uri, "uri");
-    assert_eq!(metadata.data.seller_fee_basis_points, 10);
-    assert_eq!(metadata.data.creators, None);
+        assert_eq!(metadata.data.name, "Cool");
+        assert_eq!(metadata.data.symbol, "TST");
+        assert_eq!(metadata.data.uri, "uri");
+        assert_eq!(metadata.data.seller_fee_basis_points, 10);
+        assert_eq!(metadata.data.creators, None);
 
-    assert_eq!(metadata.primary_sale_happened, false);
-    assert_eq!(metadata.is_mutable, true);
-    assert_eq!(metadata.mint, test_metadata.mint.pubkey());
-    assert_eq!(metadata.update_authority, context.payer.pubkey());
-    assert_eq!(metadata.key, Key::MetadataV1);
-}
+        assert_eq!(metadata.primary_sale_happened, false);
+        assert_eq!(metadata.is_mutable, true);
+        assert_eq!(metadata.mint, test_metadata.mint.pubkey());
+        assert_eq!(metadata.update_authority, context.payer.pubkey());
+        assert_eq!(metadata.key, Key::MetadataV1);
+    }
 
-#[tokio::test]
-async fn fail_invalid_update_authority() {
-    let mut context = program_test().start_with_context().await;
-    let test_metadata = Metadata::new();
-    let fake_update_authority = Keypair::new();
+    #[tokio::test]
+    async fn fail_invalid_update_authority() {
+        let mut context = program_test().start_with_context().await;
+        let test_metadata = Metadata::new();
+        let fake_update_authority = Keypair::new();
 
-    test_metadata
-        .create(
-            &mut context,
-            "Test".to_string(),
-            "TST".to_string(),
-            "uri".to_string(),
-            None,
-            10,
-            true,
-        )
-        .await
-        .unwrap();
+        test_metadata
+            .create(
+                &mut context,
+                "Test".to_string(),
+                "TST".to_string(),
+                "uri".to_string(),
+                None,
+                10,
+                true,
+            )
+            .await
+            .unwrap();
 
-    let tx = Transaction::new_signed_with_payer(
-        &[instruction::update_metadata_accounts(
-            id(),
-            test_metadata.pubkey,
-            fake_update_authority.pubkey(),
-            None,
-            None,
-            None,
-        )],
-        Some(&context.payer.pubkey()),
-        &[&context.payer, &fake_update_authority],
-        context.last_blockhash,
-    );
+        let tx = Transaction::new_signed_with_payer(
+            &[instruction::update_metadata_accounts(
+                id(),
+                test_metadata.pubkey,
+                fake_update_authority.pubkey(),
+                None,
+                None,
+                None,
+            )],
+            Some(&context.payer.pubkey()),
+            &[&context.payer, &fake_update_authority],
+            context.last_blockhash,
+        );
 
-    let result = context
-        .banks_client
-        .process_transaction(tx)
-        .await
-        .unwrap_err();
+        let result = context
+            .banks_client
+            .process_transaction(tx)
+            .await
+            .unwrap_err();
 
-    assert_custom_error!(result, MetadataError::UpdateAuthorityIncorrect);
+        assert_custom_error!(result, MetadataError::UpdateAuthorityIncorrect);
+    }
 }

--- a/rust/token-metadata/program/tests/update_metadata_account.rs
+++ b/rust/token-metadata/program/tests/update_metadata_account.rs
@@ -1,5 +1,11 @@
 mod utils;
 
+use metaplex_token_metadata::{
+    error::MetadataError,
+    id, instruction,
+    state::{MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH, MAX_URI_LENGTH},
+    utils::puffed_out_string,
+};
 use num_traits::FromPrimitive;
 use solana_program_test::*;
 use solana_sdk::{
@@ -8,12 +14,6 @@ use solana_sdk::{
     transaction::{Transaction, TransactionError},
     transport::TransportError,
 };
-use metaplex_token_metadata::{
-    error::MetadataError,
-    state::{MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH, MAX_URI_LENGTH},
-    utils::puffed_out_string,
-};
-use metaplex_token_metadata::{id, instruction};
 use utils::*;
 
 mod update_metadata_account {

--- a/rust/token-metadata/program/tests/update_primary_sale_happened_via_token.rs
+++ b/rust/token-metadata/program/tests/update_primary_sale_happened_via_token.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "test-bpf")]
 mod utils;
 
 use metaplex_token_metadata::{

--- a/rust/token-metadata/program/tests/update_primary_sale_happened_via_token.rs
+++ b/rust/token-metadata/program/tests/update_primary_sale_happened_via_token.rs
@@ -13,104 +13,107 @@ use metaplex_token_metadata::state::Key;
 use metaplex_token_metadata::{id, instruction};
 use utils::*;
 
-#[tokio::test]
-async fn success() {
-    let mut context = program_test().start_with_context().await;
-    let test_metadata = Metadata::new();
+mod update_primary_sale_happened_via_token {
+    use super::*;
+    #[tokio::test]
+    async fn success() {
+        let mut context = program_test().start_with_context().await;
+        let test_metadata = Metadata::new();
 
-    test_metadata
-        .create(
+        test_metadata
+            .create(
+                &mut context,
+                "Test".to_string(),
+                "TST".to_string(),
+                "uri".to_string(),
+                None,
+                10,
+                false,
+            )
+            .await
+            .unwrap();
+
+        test_metadata
+            .update_primary_sale_happened_via_token(&mut context)
+            .await
+            .unwrap();
+
+        let metadata = test_metadata.get_data(&mut context).await;
+
+        assert_eq!(metadata.data.name, "Test");
+        assert_eq!(metadata.data.symbol, "TST");
+        assert_eq!(metadata.data.uri, "uri");
+        assert_eq!(metadata.data.seller_fee_basis_points, 10);
+        assert_eq!(metadata.data.creators, None);
+
+        assert_eq!(metadata.primary_sale_happened, true);
+        assert_eq!(metadata.is_mutable, false);
+        assert_eq!(metadata.mint, test_metadata.mint.pubkey());
+        assert_eq!(metadata.update_authority, context.payer.pubkey());
+        assert_eq!(metadata.key, Key::MetadataV1);
+    }
+
+    #[tokio::test]
+    async fn fail_invalid_mint() {
+        let mut context = program_test().start_with_context().await;
+        let test_metadata = Metadata::new();
+
+        let fake_mint = Keypair::new();
+        let fake_token_account = Keypair::new();
+        let payer_pubkey = context.payer.pubkey();
+        create_mint(&mut context, &fake_mint, &payer_pubkey, None)
+            .await
+            .unwrap();
+        create_token_account(
             &mut context,
-            "Test".to_string(),
-            "TST".to_string(),
-            "uri".to_string(),
+            &fake_token_account,
+            &fake_mint.pubkey(),
+            &payer_pubkey,
+        )
+        .await
+        .unwrap();
+        mint_tokens(
+            &mut context,
+            &fake_mint.pubkey(),
+            &fake_token_account.pubkey(),
+            10000000,
+            &payer_pubkey,
             None,
-            10,
-            false,
         )
         .await
         .unwrap();
 
-    test_metadata
-        .update_primary_sale_happened_via_token(&mut context)
-        .await
-        .unwrap();
+        test_metadata
+            .create(
+                &mut context,
+                "Test".to_string(),
+                "TST".to_string(),
+                "uri".to_string(),
+                None,
+                10,
+                true,
+            )
+            .await
+            .unwrap();
 
-    let metadata = test_metadata.get_data(&mut context).await;
+        let tx = Transaction::new_signed_with_payer(
+            &[instruction::update_primary_sale_happened_via_token(
+                id(),
+                test_metadata.pubkey,
+                context.payer.pubkey(),
+                fake_token_account.pubkey(),
+            )],
+            Some(&context.payer.pubkey()),
+            &[&context.payer],
+            context.last_blockhash,
+        );
 
-    assert_eq!(metadata.data.name, "Test");
-    assert_eq!(metadata.data.symbol, "TST");
-    assert_eq!(metadata.data.uri, "uri");
-    assert_eq!(metadata.data.seller_fee_basis_points, 10);
-    assert_eq!(metadata.data.creators, None);
+        let result = context
+            .banks_client
+            .process_transaction(tx)
+            .await
+            .unwrap_err();
 
-    assert_eq!(metadata.primary_sale_happened, true);
-    assert_eq!(metadata.is_mutable, false);
-    assert_eq!(metadata.mint, test_metadata.mint.pubkey());
-    assert_eq!(metadata.update_authority, context.payer.pubkey());
-    assert_eq!(metadata.key, Key::MetadataV1);
-}
-
-#[tokio::test]
-async fn fail_invalid_mint() {
-    let mut context = program_test().start_with_context().await;
-    let test_metadata = Metadata::new();
-
-    let fake_mint = Keypair::new();
-    let fake_token_account = Keypair::new();
-    let payer_pubkey = context.payer.pubkey();
-    create_mint(&mut context, &fake_mint, &payer_pubkey, None)
-        .await
-        .unwrap();
-    create_token_account(
-        &mut context,
-        &fake_token_account,
-        &fake_mint.pubkey(),
-        &payer_pubkey,
-    )
-    .await
-    .unwrap();
-    mint_tokens(
-        &mut context,
-        &fake_mint.pubkey(),
-        &fake_token_account.pubkey(),
-        10000000,
-        &payer_pubkey,
-        None,
-    )
-    .await
-    .unwrap();
-
-    test_metadata
-        .create(
-            &mut context,
-            "Test".to_string(),
-            "TST".to_string(),
-            "uri".to_string(),
-            None,
-            10,
-            true,
-        )
-        .await
-        .unwrap();
-
-    let tx = Transaction::new_signed_with_payer(
-        &[instruction::update_primary_sale_happened_via_token(
-            id(),
-            test_metadata.pubkey,
-            context.payer.pubkey(),
-            fake_token_account.pubkey(),
-        )],
-        Some(&context.payer.pubkey()),
-        &[&context.payer],
-        context.last_blockhash,
-    );
-
-    let result = context
-        .banks_client
-        .process_transaction(tx)
-        .await
-        .unwrap_err();
-
-    assert_custom_error!(result, MetadataError::MintMismatch);
+        assert_custom_error!(result, MetadataError::MintMismatch);
+    }
 }

--- a/rust/token-metadata/program/tests/update_primary_sale_happened_via_token.rs
+++ b/rust/token-metadata/program/tests/update_primary_sale_happened_via_token.rs
@@ -11,25 +11,29 @@ use solana_sdk::{
 use metaplex_token_metadata::error::MetadataError;
 use metaplex_token_metadata::state::Key;
 use metaplex_token_metadata::{id, instruction};
+use metaplex_token_metadata::{
+    state::{MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH, MAX_URI_LENGTH},
+    utils::puffed_out_string,
+};
 use utils::*;
 
 mod update_primary_sale_happened_via_token {
+
     use super::*;
     #[tokio::test]
     async fn success() {
         let mut context = program_test().start_with_context().await;
         let test_metadata = Metadata::new();
+        let name = "Test".to_string();
+        let symbol = "TST".to_string();
+        let uri = "uri".to_string();
+
+        let puffed_name = puffed_out_string(&name, MAX_NAME_LENGTH);
+        let puffed_symbol = puffed_out_string(&symbol, MAX_SYMBOL_LENGTH);
+        let puffed_uri = puffed_out_string(&uri, MAX_URI_LENGTH);
 
         test_metadata
-            .create(
-                &mut context,
-                "Test".to_string(),
-                "TST".to_string(),
-                "uri".to_string(),
-                None,
-                10,
-                false,
-            )
+            .create(&mut context, name, symbol, uri, None, 10, false)
             .await
             .unwrap();
 
@@ -40,9 +44,9 @@ mod update_primary_sale_happened_via_token {
 
         let metadata = test_metadata.get_data(&mut context).await;
 
-        assert_eq!(metadata.data.name, "Test");
-        assert_eq!(metadata.data.symbol, "TST");
-        assert_eq!(metadata.data.uri, "uri");
+        assert_eq!(metadata.data.name, puffed_name,);
+        assert_eq!(metadata.data.symbol, puffed_symbol);
+        assert_eq!(metadata.data.uri, puffed_uri);
         assert_eq!(metadata.data.seller_fee_basis_points, 10);
         assert_eq!(metadata.data.creators, None);
 

--- a/rust/token-metadata/program/tests/update_primary_sale_happened_via_token.rs
+++ b/rust/token-metadata/program/tests/update_primary_sale_happened_via_token.rs
@@ -1,5 +1,11 @@
 mod utils;
 
+use metaplex_token_metadata::{
+    error::MetadataError,
+    id, instruction,
+    state::{Key, MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH, MAX_URI_LENGTH},
+    utils::puffed_out_string,
+};
 use num_traits::FromPrimitive;
 use solana_program_test::*;
 use solana_sdk::{
@@ -7,13 +13,6 @@ use solana_sdk::{
     signature::{Keypair, Signer},
     transaction::{Transaction, TransactionError},
     transport::TransportError,
-};
-use metaplex_token_metadata::error::MetadataError;
-use metaplex_token_metadata::state::Key;
-use metaplex_token_metadata::{id, instruction};
-use metaplex_token_metadata::{
-    state::{MAX_NAME_LENGTH, MAX_SYMBOL_LENGTH, MAX_URI_LENGTH},
-    utils::puffed_out_string,
 };
 use utils::*;
 

--- a/rust/token-metadata/program/tests/utils/edition_marker.rs
+++ b/rust/token-metadata/program/tests/utils/edition_marker.rs
@@ -1,5 +1,10 @@
 use crate::*;
 use borsh::BorshSerialize;
+use metaplex_token_metadata::{
+    id,
+    instruction::{self, MetadataInstruction, MintNewEditionFromMasterEditionViaTokenArgs},
+    state::{EDITION, EDITION_MARKER_BIT_SIZE, PREFIX},
+};
 use solana_program::{
     borsh::try_from_slice_unchecked,
     instruction::{AccountMeta, Instruction},
@@ -9,11 +14,6 @@ use solana_program_test::*;
 use solana_sdk::{
     pubkey::Pubkey, signature::Signer, signer::keypair::Keypair, transaction::Transaction,
     transport,
-};
-use metaplex_token_metadata::{
-    id,
-    instruction::{self, MetadataInstruction, MintNewEditionFromMasterEditionViaTokenArgs},
-    state::{EDITION, EDITION_MARKER_BIT_SIZE, PREFIX},
 };
 
 #[derive(Debug)]
@@ -98,7 +98,8 @@ impl EditionMarker {
             metaplex_token_vault_id.as_ref(),
             vault_pubkey.as_ref(),
         ];
-        let (_authority, _) = Pubkey::find_program_address(vault_mint_seeds, &metaplex_token_vault_id);
+        let (_authority, _) =
+            Pubkey::find_program_address(vault_mint_seeds, &metaplex_token_vault_id);
 
         create_mint(context, &self.mint, &context.payer.pubkey(), None).await?;
         create_token_account(

--- a/rust/token-metadata/program/tests/utils/external_price.rs
+++ b/rust/token-metadata/program/tests/utils/external_price.rs
@@ -1,11 +1,11 @@
 use crate::*;
+use metaplex_token_vault::instruction;
 use solana_program::{borsh::try_from_slice_unchecked, system_instruction};
 use solana_program_test::*;
 use solana_sdk::{
     pubkey::Pubkey, signature::Signer, signer::keypair::Keypair, transaction::Transaction,
     transport,
 };
-use metaplex_token_vault::instruction;
 
 #[derive(Debug)]
 pub struct ExternalPrice {

--- a/rust/token-metadata/program/tests/utils/master_edition_v2.rs
+++ b/rust/token-metadata/program/tests/utils/master_edition_v2.rs
@@ -1,17 +1,21 @@
 use crate::*;
 use borsh::ser::BorshSerialize;
-use solana_program::borsh::try_from_slice_unchecked;
-use solana_program::{
-    instruction::{AccountMeta, Instruction},
-    sysvar,
-};
-use solana_program_test::*;
-use solana_sdk::signature::Keypair;
-use solana_sdk::{pubkey::Pubkey, signature::Signer, transaction::Transaction, transport};
 use metaplex_token_metadata::{
     id,
     instruction::{self, CreateMasterEditionArgs, MetadataInstruction},
     state::{EDITION, PREFIX},
+};
+use solana_program::{
+    borsh::try_from_slice_unchecked,
+    instruction::{AccountMeta, Instruction},
+    sysvar,
+};
+use solana_program_test::*;
+use solana_sdk::{
+    pubkey::Pubkey,
+    signature::{Keypair, Signer},
+    transaction::Transaction,
+    transport,
 };
 
 #[derive(Debug)]

--- a/rust/token-metadata/program/tests/utils/metadata.rs
+++ b/rust/token-metadata/program/tests/utils/metadata.rs
@@ -1,13 +1,13 @@
 use crate::*;
+use metaplex_token_metadata::{
+    id, instruction,
+    state::{Creator, Data, PREFIX},
+};
 use solana_program::borsh::try_from_slice_unchecked;
 use solana_program_test::*;
 use solana_sdk::{
     pubkey::Pubkey, signature::Signer, signer::keypair::Keypair, transaction::Transaction,
     transport,
-};
-use metaplex_token_metadata::{
-    id, instruction,
-    state::{Creator, Data, PREFIX},
 };
 
 #[derive(Debug)]

--- a/rust/token-metadata/program/tests/utils/mod.rs
+++ b/rust/token-metadata/program/tests/utils/mod.rs
@@ -19,7 +19,11 @@ use spl_token::state::Mint;
 pub use vault::Vault;
 
 pub fn program_test<'a>() -> ProgramTest {
-    ProgramTest::new("metaplex_token_metadata", metaplex_token_metadata::id(), None)
+    ProgramTest::new(
+        "metaplex_token_metadata",
+        metaplex_token_metadata::id(),
+        None,
+    )
 }
 
 pub async fn get_account(context: &mut ProgramTestContext, pubkey: &Pubkey) -> Account {

--- a/rust/token-metadata/program/tests/utils/vault.rs
+++ b/rust/token-metadata/program/tests/utils/vault.rs
@@ -1,4 +1,5 @@
 use super::{create_mint, create_token_account, ExternalPrice, Metadata};
+use metaplex_token_vault::{instruction, state::PREFIX};
 use solana_program::{pubkey::Pubkey, system_instruction};
 use solana_program_test::*;
 use solana_sdk::{
@@ -6,7 +7,6 @@ use solana_sdk::{
     transaction::Transaction,
     transport,
 };
-use metaplex_token_vault::{instruction, state::PREFIX};
 
 pub struct Vault {
     pub keypair: Keypair,


### PR DESCRIPTION
This PR focuses mostly on fixing token-metadata tests that were broken.
As part of this build errors needed to be fixed in the auction tests.

NOTE: the formatting changes and _in module wrapping_ create a lot of noise especially in the tests, therefore to focus on actual changes to the tests please refer to this https://github.com/metaplex-foundation/metaplex/pull/881/commits/2e9431f7066f4ace4d59815730b045a1c3f86309

The main fix entailed expecting strings to be _puffed out_ to have a deterministic length.
Some docs were added around and a method factored out to be useable from both the program
itself as well as the tests.

I also wrapped each test file in a module in order to be able to run them in isolation + get improved failure/success output, see https://github.com/metaplex-foundation/metaplex/pull/881/commits/14a147e995af5825ec14df0f6d657476a6b71687.

Since the imports were very unorganized I added a rustfmt at the end and reformatted all code
to match it.

I chose `max_width = 100` since that matched the existing code, however if we want to change
this to `80` instead I can update the PR.
If these style changes shouldn't be part of this at all I can back those commits out and we can
add them in a later PR.

### Follow Up

- next I'll get these tests to run in CI an pass
- after that I'll look through the contract and existing tests in more detail and will add more tests were needed (right now one success test and only to failure case tests exist for each instruction)