### PR TITLE
Make edition zero mint invalid

### DIFF
--- a/rust/token-metadata/program/src/error.rs
+++ b/rust/token-metadata/program/src/error.rs
@@ -306,6 +306,10 @@ pub enum MetadataError {
     // In the legacy system the reservation needs to be of size one for cpu limit reasons
     #[error("In the legacy system the reservation needs to be of size one for cpu limit reasons")]
     ReservationArrayShouldBeSizeOne,
+
+    /// When specifying an edition override, 0 is an invalid value
+    #[error("Zero is an invalid metadata limited edition")]
+    EditionZeroIsInvalid,
 }
 
 impl PrintProgramError for MetadataError {

--- a/rust/token-metadata/program/src/utils.rs
+++ b/rust/token-metadata/program/src/utils.rs
@@ -492,6 +492,9 @@ pub fn calculate_supply_change<'a>(
     if reservation_list_info.is_none() {
         let new_supply: u64;
         if let Some(edition) = edition_override {
+            if edition == 0 {
+                return Err(MetadataError::EditionZeroIsInvalid.into());
+            }
             if edition > me_supply {
                 new_supply = edition;
             } else {


### PR DESCRIPTION
- Otherwise we can mint 1 more than max supply, i.e the 0/n mint