### PR TITLE
Add max supply functionality in candy machine

### DIFF
--- a/js/packages/cli/src/candy-machine-cli.ts
+++ b/js/packages/cli/src/candy-machine-cli.ts
@@ -77,6 +77,10 @@ programCommand('upload')
     '-r, --rpc-url <string>',
     'custom rpc url since this is a heavy command',
   )
+  .option(
+    '-m, --max_supply <string>',
+    'max supply JSON file for each NFT (ex: {"0": 3, "1": 100})',
+  )
   .action(async (files: string[], options, cmd) => {
     const {
       number,
@@ -90,6 +94,7 @@ programCommand('upload')
       retainAuthority,
       mutable,
       rpcUrl,
+      max_supply,
     } = cmd.opts();
 
     if (storage === 'ipfs' && (!ipfsInfuraProjectId || !ipfsInfuraSecret)) {
@@ -152,6 +157,7 @@ programCommand('upload')
         rpcUrl,
         ipfsCredentials,
         awsS3Bucket,
+        max_supply,
       );
 
       if (successful) {

--- a/js/packages/cli/src/commands/upload.ts
+++ b/js/packages/cli/src/commands/upload.ts
@@ -9,6 +9,7 @@ import { PublicKey } from '@solana/web3.js';
 import fs from 'fs';
 import { BN } from '@project-serum/anchor';
 import { loadCache, saveCache } from '../helpers/cache';
+import { loadMaxSupply } from '../helpers/maxSupply';
 import log from 'loglevel';
 import { awsUpload } from '../helpers/upload/aws';
 import { arweaveUpload } from '../helpers/upload/arweave';
@@ -27,6 +28,7 @@ export async function upload(
   rpcUrl: string,
   ipfsCredentials: ipfsCreds,
   awsS3Bucket: string,
+  max_supply: string,
 ): Promise<boolean> {
   let uploadSuccessful = true;
 
@@ -70,6 +72,7 @@ export async function upload(
     ? new PublicKey(cacheContent.program.config)
     : undefined;
 
+  const max_supplies = loadMaxSupply(max_supply);
   for (let i = 0; i < SIZE; i++) {
     const image = images[i];
     const imageName = path.basename(image);
@@ -102,7 +105,7 @@ export async function upload(
             symbol: manifest.symbol,
             sellerFeeBasisPoints: manifest.seller_fee_basis_points,
             isMutable: mutable,
-            maxSupply: new BN(0),
+            maxSupply: new BN(max_supplies[i.toString()]),
             retainAuthority: retainAuthority,
             creators: manifest.properties.creators.map(creator => {
               return {

--- a/js/packages/cli/src/helpers/maxSupply.ts
+++ b/js/packages/cli/src/helpers/maxSupply.ts
@@ -1,0 +1,7 @@
+import fs from 'fs';
+
+export function loadMaxSupply(maxSupplyPath: string) {
+  return fs.existsSync(maxSupplyPath)
+    ? JSON.parse(fs.readFileSync(maxSupplyPath).toString())
+    : undefined;
+}


### PR DESCRIPTION
I have added a new feature in candy machine that allow the user to select a max supply for each NFT created when calling the upload function. 
This flag is optional and when not used, the NFT is created with a max supply of 0, as it is by default at this moment.

I have added a new argument in the upload command that receives the path to a json file that should have the following structure:
`{
    "0": 10,
    "1": 123,
    "2": 4
}`

This file matches the number of each NFT with the intended max supply.

I believe this is an important feature for people that want to have an option on the max supply of their NFTs.