### PR TITLE
fix(candy-cli): rewrite create_generative_art command for speed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ incremented for features.
 ### Fixes
 
 - Fixes #840 - Claim button visible after claim.
+- Improve Candy Machine CLI `create_generative_art` command performance. (@0xCryptoSheik in #899)
 
 ### Breaking
 


### PR DESCRIPTION
### Changes

- instanciate asynchronous workers to create images from random sets.
- the number of asynchronous workers is set to the number of CPUs by default, can be overriden for fine-tuning.
- each worker is instanciated with its own canvas, which allows for theoretically less expensive GC & stuff.
- make all filesystem operations asynchronous using fs/promises.
- for better performance, make sure to use the built CLI and run it with node (npm run build before), & *NOT* the ts-node version.

```
$ time node build/candy-machine-cli.js create_generative_art -c traits-configuration.json -n 20
```
### Before

```
real    0m17.098s
user    0m10.455s
sys     0m9.205s
```
- measured inside `createArt` function: `13021ms`

### After

```
real    0m10.743s
user    0m9.673s
sys     0m6.948s
```

- measured inside `createArt` function: `9142ms`

About 30% faster on my dev vm with 2 CPU cores & 2GB RAM.

Technical storytelling: https://twitter.com/0xCryptoSheik/status/1456985296147464198?s=20