### PR TITLE
fix: packs creation with multiple assets

### DIFF
--- a/js/packages/common/src/actions/packs.ts
+++ b/js/packages/common/src/actions/packs.ts
@@ -28,39 +28,34 @@ export async function getProgramAuthority(): Promise<StringPublicKey> {
 
 export async function findPackCardProgramAddress(
   pack: PublicKey,
-  index: BN,
+  index: number,
 ): Promise<StringPublicKey> {
   return findProgramAddressByPrefix(pack, index, CARD_PREFIX);
 }
 
 export async function findPackVoucherProgramAddress(
   pack: PublicKey,
-  index: BN,
+  index: number,
 ): Promise<StringPublicKey> {
   return findProgramAddressByPrefix(pack, index, VOUCHER_PREFIX);
 }
 
 async function findProgramAddressByPrefix(
   packSetKey: PublicKey,
-  index: BN,
+  index: number,
   prefix: string,
 ): Promise<StringPublicKey> {
   const PROGRAM_IDS = programIds();
 
+  const numberBuffer = Buffer.allocUnsafe(4);
+  numberBuffer.writeUInt16LE(index);
+
   return (
     await findProgramAddress(
-      [
-        Buffer.from(prefix),
-        new PublicKey(packSetKey).toBuffer(),
-        new Uint8Array(numberToBytesArray(index.toNumber(), 4)),
-      ],
+      [Buffer.from(prefix), new PublicKey(packSetKey).toBuffer(), numberBuffer],
       toPublicKey(PROGRAM_IDS.pack_create),
     )
   )[0];
-}
-
-function numberToBytesArray(number: number, length: number) {
-  return [...Array(length)].map((x, i) => (number >> i) & 1);
 }
 
 export class InitPackSetArgs {
@@ -90,7 +85,7 @@ export class AddCardToPackArgs {
   instruction = 1;
   maxSupply: BN | null;
   weight: BN | null;
-  index: BN;
+  index: number;
 
   constructor(args: AddCardToPackParams) {
     this.maxSupply = args.maxSupply;

--- a/js/packages/common/src/models/packs/instructions/addCardToPack.ts
+++ b/js/packages/common/src/models/packs/instructions/addCardToPack.ts
@@ -35,7 +35,7 @@ export async function addCardToPack({
   mint,
   tokenAccount,
   toAccount,
-}: Params): Promise<TransactionInstruction> {
+}: Params): Promise<TransactionInstruction[]> {
   const PROGRAM_IDS = programIds();
 
   const value = new AddCardToPackArgs({
@@ -137,9 +137,11 @@ export async function addCardToPack({
     },
   ];
 
-  return new TransactionInstruction({
-    keys,
-    programId: toPublicKey(PROGRAM_IDS.pack_create),
-    data,
-  });
+  return [
+    new TransactionInstruction({
+      keys,
+      programId: toPublicKey(PROGRAM_IDS.pack_create),
+      data,
+    }),
+  ];
 }

--- a/js/packages/common/src/models/packs/instructions/addVoucherToPack.ts
+++ b/js/packages/common/src/models/packs/instructions/addVoucherToPack.ts
@@ -4,7 +4,6 @@ import {
   SYSVAR_RENT_PUBKEY,
   SystemProgram,
 } from '@solana/web3.js';
-import BN from 'bn.js';
 import { serialize } from 'borsh';
 
 import { TokenAccount } from '../..';
@@ -18,7 +17,7 @@ import {
 import { StringPublicKey, programIds, toPublicKey } from '../../../utils';
 
 interface Params {
-  index: BN;
+  index: number;
   packSetKey: PublicKey;
   authority: StringPublicKey;
   mint: StringPublicKey;
@@ -31,7 +30,7 @@ export async function addVoucherToPack({
   authority,
   mint,
   tokenAccount,
-}: Params): Promise<TransactionInstruction> {
+}: Params): Promise<TransactionInstruction[]> {
   const PROGRAM_IDS = programIds();
 
   const value = new AddVoucherToPackArgs();
@@ -122,9 +121,11 @@ export async function addVoucherToPack({
     },
   ];
 
-  return new TransactionInstruction({
-    keys,
-    programId: toPublicKey(PROGRAM_IDS.pack_create),
-    data,
-  });
+  return [
+    new TransactionInstruction({
+      keys,
+      programId: toPublicKey(PROGRAM_IDS.pack_create),
+      data,
+    }),
+  ];
 }

--- a/js/packages/common/src/models/packs/interface.ts
+++ b/js/packages/common/src/models/packs/interface.ts
@@ -15,5 +15,5 @@ export interface InitPackSetParams {
 export interface AddCardToPackParams {
   maxSupply: BN | null;
   weight: BN | null;
-  index: BN;
+  index: number;
 }

--- a/js/packages/web/src/views/packCreate/interface.ts
+++ b/js/packages/web/src/views/packCreate/interface.ts
@@ -29,13 +29,13 @@ export interface SelectedItem {
   weight: BN;
   tokenAccount: TokenAccount;
   toAccount: Keypair;
-  index: BN;
+  index: number;
 }
 
 export interface SelectedVoucher {
   mint: string;
   tokenAccount: TokenAccount;
-  index: BN;
+  index: number;
 }
 
 export interface MapSelectedItemsParams

--- a/js/packages/web/src/views/packCreate/transactions/createPack.ts
+++ b/js/packages/web/src/views/packCreate/transactions/createPack.ts
@@ -63,6 +63,7 @@ const generateCreatePackInstructions = async ({
     accountByMint,
     distributionType,
   });
+
   // Create accounts for token transfer
   const createTokenAccountsInstructions = await getCreateTokenAccounts({
     cardsToAdd,
@@ -96,11 +97,17 @@ const generateCreatePackInstructions = async ({
     instructions: [
       [createAccountInstruction, initPackSetInstruction],
       createTokenAccountsInstructions,
-      addCardToPackInstructions,
-      addVoucherToPackInstructions,
+      ...addCardToPackInstructions,
+      ...addVoucherToPackInstructions,
       [activateInstruction],
     ],
-    signers: [[packSet], cardsTokens, [], [], []],
+    signers: [
+      [packSet],
+      cardsTokens,
+      ...addCardToPackInstructions.map(() => []),
+      ...addVoucherToPackInstructions.map(() => []),
+      [],
+    ],
   };
 };
 

--- a/js/packages/web/src/views/packCreate/transactions/getAddCardToPack.ts
+++ b/js/packages/web/src/views/packCreate/transactions/getAddCardToPack.ts
@@ -7,7 +7,7 @@ export const getAddCardToPack = async ({
   selectedItems,
   packSetKey,
   walletPublicKey,
-}: GetAddCardToPackParams): Promise<TransactionInstruction[]> => {
+}: GetAddCardToPackParams): Promise<TransactionInstruction[][]> => {
   const addCardsToPack = selectedItems.map(selectedItem => {
     return addCardToPack({
       ...selectedItem,

--- a/js/packages/web/src/views/packCreate/transactions/getAddVoucherToPack.ts
+++ b/js/packages/web/src/views/packCreate/transactions/getAddVoucherToPack.ts
@@ -7,7 +7,7 @@ export const getAddVoucherToPack = async ({
   selectedVouchers,
   packSetKey,
   walletPublicKey,
-}: GetAddVoucherToPackParams): Promise<TransactionInstruction[]> => {
+}: GetAddVoucherToPackParams): Promise<TransactionInstruction[][]> => {
   const addVouchersToPack = selectedVouchers.map(voucher => {
     return addVoucherToPack({
       ...voucher,

--- a/js/packages/web/src/views/packCreate/utils.ts
+++ b/js/packages/web/src/views/packCreate/utils.ts
@@ -99,7 +99,7 @@ export const mapSelectedItems = ({
     const toAccount = Keypair.generate();
 
     return {
-      index: new BN(index + 1), // Packs indexing starts from 1
+      index: index + 1, // Packs indexing starts from 1
       mint,
       maxSupply,
       weight,
@@ -120,7 +120,7 @@ export const mapSelectedVouchers = ({
       throw new Error(`No token account for the metadata: ${pubKey}`);
 
     return {
-      index: new BN(index + 1), // Packs indexing starts from 1
+      index: index + 1, // Packs indexing starts from 1
       mint,
       tokenAccount,
     };


### PR DESCRIPTION
- Use proper index conversion to Little Endian.
- Split AddCardToPack transactions