### PR TITLE
Modify trade state account structure

### DIFF
--- a/rust/auction-house/src/lib.rs
+++ b/rust/auction-house/src/lib.rs
@@ -1345,11 +1345,12 @@ pub const AUCTION_HOUSE_SIZE: usize = 8 + //key
 32 + //treasury mint
 32 + //authority
 32 + // creator
-8 + // bump
-8 + // treasury_bump
-8 + // fee_payer_bump
+1 + // bump
+1 + // treasury_bump
+1 + // fee_payer_bump
 2 + // seller fee basis points
 1 + // requires sign off
+1 + // can change sale price
 200; //padding
 
 #[account]

--- a/rust/auction-house/src/lib.rs
+++ b/rust/auction-house/src/lib.rs
@@ -1351,7 +1351,7 @@ pub const AUCTION_HOUSE_SIZE: usize = 8 + //key
 2 + // seller fee basis points
 1 + // requires sign off
 1 + // can change sale price
-200; //padding
+221; //padding
 
 #[account]
 pub struct AuctionHouse {


### PR DESCRIPTION
An example of how trade state accounts can be made more descriptive for better querying via memcmp filters from a client. There are a couple of good use cases for this. The first would be that it'd be simpler for an offchain crank to simply query the contract itself and isolate for the trade state accounts it needs to execute a sale. The other would be that if multiple markets all launched their own auction house contracts, having descriptive buyer/seller trade state accounts would allow people to track bids/asks on auction house accounts across all instances of the contract they're watching with a predictable interface made available via the account structure. 

The PR proposes such a change to the buyer trade state account. I only did it here as a template and if it looks good, will do the same thing for seller trade state accounts.