### PR TITLE
fix(connection): ensure stable network connection

### DIFF
--- a/js/packages/common/src/components/Settings/index.tsx
+++ b/js/packages/common/src/components/Settings/index.tsx
@@ -15,7 +15,7 @@ export const Settings = ({
   additionalSettings?: JSX.Element;
 }) => {
   const { connected, disconnect, publicKey } = useWallet();
-  const { endpoint, setEndpoint } = useConnectionConfig();
+  const { endpoint } = useConnectionConfig();
   const { setVisible } = useWalletModal();
   const open = useCallback(() => setVisible(true), [setVisible]);
 

--- a/js/packages/common/src/components/TokenIcon/index.tsx
+++ b/js/packages/common/src/components/TokenIcon/index.tsx
@@ -15,8 +15,8 @@ export const TokenIcon = (props: {
   if (props.tokenMap) {
     icon = getTokenIcon(props.tokenMap, props.mintAddress);
   } else {
-    const { tokenMap } = useConnectionConfig();
-    icon = getTokenIcon(tokenMap, props.mintAddress);
+    const { tokens } = useConnectionConfig();
+    icon = getTokenIcon(tokens, props.mintAddress);
   }
 
   const size = props.size || 20;

--- a/js/packages/common/src/hooks/useQuerySearch.ts
+++ b/js/packages/common/src/hooks/useQuerySearch.ts
@@ -1,5 +1,7 @@
+import { useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 
 export function useQuerySearch() {
-  return new URLSearchParams(useLocation().search);
+  const { search } = useLocation();
+  return useMemo(() => new URLSearchParams(search), [search]);
 }

--- a/js/packages/common/src/hooks/useTokenName.ts
+++ b/js/packages/common/src/hooks/useTokenName.ts
@@ -3,8 +3,8 @@ import { useConnectionConfig } from '../contexts/connection';
 import { getTokenName } from '../utils/utils';
 
 export function useTokenName(mintAddress?: string | PublicKey) {
-  const { tokenMap } = useConnectionConfig();
+  const { tokens } = useConnectionConfig();
   const address =
     typeof mintAddress === 'string' ? mintAddress : mintAddress?.toBase58();
-  return getTokenName(tokenMap, address);
+  return getTokenName(tokens, address);
 }

--- a/js/packages/common/src/utils/utils.ts
+++ b/js/packages/common/src/utils/utils.ts
@@ -16,11 +16,15 @@ export const formatPriceNumber = new Intl.NumberFormat('en-US', {
   maximumFractionDigits: 8,
 });
 
-export function useLocalStorageState(key: string, defaultState?: string) {
+export function useLocalStorageState<T>(
+  key: string,
+  defaultState?: T,
+): [T, (key: string) => void] {
   const localStorage = useLocalStorage();
   const [state, setState] = useState(() => {
-    // NOTE: Not sure if this is ok
+    console.debug('Querying local storage', key);
     const storedState = localStorage.getItem(key);
+    console.debug('Retrieved local storage', storedState);
     if (storedState) {
       return JSON.parse(storedState);
     }

--- a/js/packages/web/src/actions/nft.tsx
+++ b/js/packages/web/src/actions/nft.tsx
@@ -4,7 +4,7 @@ import {
   createMetadata,
   programIds,
   notify,
-  ENV,
+  ENDPOINT_NAME,
   updateMetadata,
   createMasterEdition,
   sendTransactionWithRetry,
@@ -74,7 +74,7 @@ const uploadToArweave = async (data: FormData): Promise<IArweaveResult> => {
 export const mintNFT = async (
   connection: Connection,
   wallet: WalletSigner | undefined,
-  env: ENV,
+  endpoint: ENDPOINT_NAME,
   files: File[],
   metadata: {
     name: string;
@@ -225,7 +225,7 @@ export const mintNFT = async (
   // this means we're done getting AR txn setup. Ship it off to ARWeave!
   const data = new FormData();
   data.append('transaction', txid);
-  data.append('env', env);
+  data.append('env', endpoint);
 
   const tags = realFiles.reduce(
     (acc: Record<string, Array<{ name: string; value: string }>>, f) => {

--- a/js/packages/web/src/components/CurrentUserBadge/index.tsx
+++ b/js/packages/web/src/components/CurrentUserBadge/index.tsx
@@ -1,6 +1,9 @@
 import React, { useCallback, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
 
+import { useWallet } from '@solana/wallet-adapter-react';
 import { LAMPORTS_PER_SOL, PublicKey } from '@solana/web3.js';
+import { Button, Popover, Select } from 'antd';
 import {
   ENDPOINTS,
   formatNumber,
@@ -12,14 +15,12 @@ import {
   useConnectionConfig,
   useNativeAccount,
   useWalletModal,
+  useQuerySearch,
   WRAPPED_SOL_MINT,
 } from '@oyster/common';
-import { useWallet } from '@solana/wallet-adapter-react';
-import { Button, Popover, Select } from 'antd';
 import { useMeta, useSolPrice } from '../../contexts';
-import { Link } from 'react-router-dom';
-import { TokenCircle } from '../Custom';
 import { useTokenList } from '../../contexts/tokenList';
+import { TokenCircle } from '../Custom';
 
 ('@solana/wallet-adapter-base');
 
@@ -214,7 +215,7 @@ export const CurrentUserBadge = (props: {
   }
   const balance = (account?.lamports || 0) / LAMPORTS_PER_SOL;
   const balanceInUSD = balance * solPrice;
-  const solMintInfo = useTokenList().tokenMap.get(WRAPPED_SOL_MINT.toString())
+  const solMintInfo = useTokenList().tokenMap.get(WRAPPED_SOL_MINT.toString());
   const iconStyle: React.CSSProperties = {
     display: 'flex',
     width: props.iconSize,
@@ -228,7 +229,7 @@ export const CurrentUserBadge = (props: {
   }
 
   let image = <Identicon address={publicKey?.toBase58()} style={iconStyle} />;
-  
+
   if (unknownWallet.image) {
     image = <img src={unknownWallet.image} style={iconStyle} />;
   }
@@ -265,7 +266,9 @@ export const CurrentUserBadge = (props: {
                     marginBottom: 10,
                   }}
                 >
-                  <TokenCircle iconFile={solMintInfo? solMintInfo.logoURI:""}/>
+                  <TokenCircle
+                    iconFile={solMintInfo ? solMintInfo.logoURI : ''}
+                  />
                   &nbsp;
                   <span
                     style={{
@@ -338,7 +341,8 @@ export const CurrentUserBadge = (props: {
 };
 
 export const Cog = () => {
-  const { endpoint, setEndpoint } = useConnectionConfig();
+  const { endpoint } = useConnectionConfig();
+  const routerSearchParams = useQuerySearch();
   const { setVisible } = useWalletModal();
   const open = useCallback(() => setVisible(true), [setVisible]);
 
@@ -362,8 +366,28 @@ export const Cog = () => {
               NETWORK
             </h5>
             <Select
-              onSelect={setEndpoint}
-              value={endpoint}
+              onSelect={network => {
+                // Reload the page, forward user selection to the URL querystring.
+                // The app will be re-initialized with the correct network
+                // (which will also be saved to local storage for future visits)
+                // for all its lifecycle.
+
+                // Because we use react-router's HashRouter, we must append
+                // the query parameters to the window location's hash & reload
+                // explicitly. We cannot update the window location's search
+                // property the standard way, see examples below.
+
+                // doesn't work: https://localhost/?network=devnet#/
+                // works: https://localhost/#/?network=devnet
+                const windowHash = window.location.hash;
+                routerSearchParams.set('network', network);
+                const nextLocationHash = `${
+                  windowHash.split('?')[0]
+                }?${routerSearchParams.toString()}`;
+                window.location.hash = nextLocationHash;
+                window.location.reload();
+              }}
+              value={endpoint.name}
               bordered={false}
               style={{
                 background: 'rgba(255, 255, 255, 0.05)',
@@ -372,8 +396,8 @@ export const Cog = () => {
                 marginBottom: 10,
               }}
             >
-              {ENDPOINTS.map(({ name, endpoint }) => (
-                <Select.Option value={endpoint} key={endpoint}>
+              {ENDPOINTS.map(({ name }) => (
+                <Select.Option value={name} key={endpoint.name}>
                   {name}
                 </Select.Option>
               ))}

--- a/js/packages/web/src/components/Settings/index.tsx
+++ b/js/packages/web/src/components/Settings/index.tsx
@@ -1,26 +1,47 @@
 import React from 'react';
 import { Button, Select } from 'antd';
-import { contexts } from '@oyster/common';
 import { useWallet } from '@solana/wallet-adapter-react';
+import { contexts, useQuerySearch } from '@oyster/common';
 
 const { ENDPOINTS, useConnectionConfig } = contexts.Connection;
 
 export const Settings = () => {
   const { connected, disconnect } = useWallet();
-  const { endpoint, setEndpoint } = useConnectionConfig();
+  const { endpoint } = useConnectionConfig();
+  const routerSearchParams = useQuerySearch();
 
   return (
     <>
       <div style={{ display: 'grid' }}>
         Network:{' '}
         <Select
-          onSelect={setEndpoint}
-          value={endpoint}
+          onSelect={network => {
+            // Reload the page, forward user selection to the URL querystring.
+            // The app will be re-initialized with the correct network
+            // (which will also be saved to local storage for future visits)
+            // for all its lifecycle.
+
+            // Because we use react-router's HashRouter, we must append
+            // the query parameters to the window location's hash & reload
+            // explicitly. We cannot update the window location's search
+            // property the standard way, see examples below.
+
+            // doesn't work: https://localhost/?network=devnet#/
+            // works: https://localhost/#/?network=devnet
+            const windowHash = window.location.hash;
+            routerSearchParams.set('network', network);
+            const nextLocationHash = `${
+              windowHash.split('?')[0]
+            }?${routerSearchParams.toString()}`;
+            window.location.hash = nextLocationHash;
+            window.location.reload();
+          }}
+          value={endpoint.name}
           style={{ marginBottom: 20 }}
         >
-          {ENDPOINTS.map(({ name, endpoint }) => (
-            <Select.Option value={endpoint} key={endpoint}>
-              {name}
+          {ENDPOINTS.map(({ name, label }) => (
+            <Select.Option value={name} key={name}>
+              {label}
             </Select.Option>
           ))}
         </Select>

--- a/js/packages/web/src/components/ViewOn/index.tsx
+++ b/js/packages/web/src/components/ViewOn/index.tsx
@@ -4,7 +4,7 @@ import { useArt } from '../../hooks';
 import { useConnectionConfig } from '@oyster/common';
 
 export const ViewOn = ({ id }: { id: string }) => {
-  const { env } = useConnectionConfig();
+  const { endpoint } = useConnectionConfig();
   const art = useArt(id);
 
   return (
@@ -20,14 +20,17 @@ export const ViewOn = ({ id }: { id: string }) => {
           </Button>
           <Button
             className="tag"
-            onClick={() =>
-              window.open(
-                `https://explorer.solana.com/account/${art?.mint || ''}${
-                  env.indexOf('main') >= 0 ? '' : `?cluster=${env}`
-                }`,
-                '_blank',
-              )
-            }
+            onClick={() => {
+              const cluster = endpoint.name;
+              const explorerURL = new URL(
+                `account/${art?.mint || ''}`,
+                'https://explorer.solana.com',
+              );
+              if (!cluster.includes('mainnet')) {
+                explorerURL.searchParams.set('cluster', cluster);
+              }
+              window.open(explorerURL.href, '_blank');
+            }}
           >
             Solana
           </Button>

--- a/js/packages/web/src/views/artCreate/index.tsx
+++ b/js/packages/web/src/views/artCreate/index.tsx
@@ -23,7 +23,6 @@ import {
   MAX_METADATA_LEN,
   useConnection,
   IMetadataExtension,
-  Attribute,
   MetadataCategory,
   useConnectionConfig,
   Creator,
@@ -34,7 +33,7 @@ import {
   StringPublicKey,
   WRAPPED_SOL_MINT,
   getAssetCostToStore,
-  LAMPORT_MULTIPLIER
+  LAMPORT_MULTIPLIER,
 } from '@oyster/common';
 import { useWallet } from '@solana/wallet-adapter-react';
 import { Connection } from '@solana/web3.js';
@@ -56,7 +55,7 @@ const { Text } = Typography;
 
 export const ArtCreateView = () => {
   const connection = useConnection();
-  const { env } = useConnectionConfig();
+  const { endpoint } = useConnectionConfig();
   const wallet = useWallet();
   const [alertMessage, setAlertMessage] = useState<string>();
   const { step_param }: { step_param: string } = useParams();
@@ -123,7 +122,7 @@ export const ArtCreateView = () => {
       const _nft = await mintNFT(
         connection,
         wallet,
-        env,
+        endpoint.name,
         files,
         metadata,
         setNFTcreateProgress,
@@ -1129,7 +1128,13 @@ const LaunchStep = (props: {
             suffix="%"
           />
           {cost ? (
-            <AmountLabel title="Cost to Create" amount={cost.toFixed(5)} tokenInfo={useTokenList().tokenMap.get(WRAPPED_SOL_MINT.toString())} />
+            <AmountLabel
+              title="Cost to Create"
+              amount={cost.toFixed(5)}
+              tokenInfo={useTokenList().tokenMap.get(
+                WRAPPED_SOL_MINT.toString(),
+              )}
+            />
           ) : (
             <Spin />
           )}


### PR DESCRIPTION
- changing the Solana "network" endpoint now reloads the app fully to avoid possible side-effects, race-conditions, bugs, ...
- the "network" endpoint is now determined only once on app mount, by priority:
  - from the `network` **hash-router querystring param**
  - from the `network` **local storage key/value**
  - **default** (`mainnet-beta` / `api.metaplex.solana.com`)
- `useQuerySearch` hook is now properly memoized to prevent unnecessary rendering of its consumers, if the `location` from react-router hash-router changes, but not the `search` property.
- `ConnectionContext` no longer triggers unnecessary re-renders of its consumers thanks to a memoized provider value.
- `ConnectionContext` now only exposes `{ connection: Connection, endpoint: Endpoint, tokens: Map<string, TokenInfo> }`, redundant values have been removed & migrated.
- general code-cleanup of packages/common/contexts/connection (types, naming, ...).
- miscellaneous changes (prettier, trivial types, ...)

Related to #930