### PR TITLE
Allow limited edition to inherit metadata mutability from master NFT.

### DIFF
--- a/rust/token-metadata/program/src/utils.rs
+++ b/rust/token-metadata/program/src/utils.rs
@@ -592,7 +592,7 @@ pub fn mint_limited_edition<'a>(
         },
         master_metadata.data,
         true,
-        false,
+        master_metadata.is_mutable,
     )?;
     let edition_authority_seeds = &[
         PREFIX.as_bytes(),


### PR DESCRIPTION
Aims to resolve #951 