### PR TITLE
fix: comment out DesignAndInfo from Header per d8202c3

### DIFF
--- a/js/packages/web/src/views/packCreate/components/Header/data.ts
+++ b/js/packages/web/src/views/packCreate/components/Header/data.ts
@@ -14,9 +14,9 @@ export const HEADER_CONTENT: Record<CreatePackSteps, HeaderContentRecord> = {
   // [CreatePackSteps.SalesSettings]: {
   //   title: 'Pricing & Expiration ',
   // },
-  [CreatePackSteps.DesignAndInfo]: {
-    title: 'Design your pack',
-  },
+  // [CreatePackSteps.DesignAndInfo]: {
+  //   title: 'Design your pack',
+  // },
   [CreatePackSteps.ReviewAndMint]: {
     title: 'Review and mint your pack',
   },


### PR DESCRIPTION
in commit d8202c3, the `DesignAndInfo` property reference was not removed from the `Header` component

fixes https://github.com/metaplex-foundation/metaplex/issues/980