### PR TITLE
Added support for GIF to the candy-machine-cli upload command

### DIFF
--- a/js/packages/cli/src/candy-machine-cli.ts
+++ b/js/packages/cli/src/candy-machine-cli.ts
@@ -19,6 +19,7 @@ import {
   CONFIG_LINE_SIZE,
   EXTENSION_JSON,
   EXTENSION_PNG,
+  EXTENSION_GIF,
   CANDY_MACHINE_PROGRAM_ID,
 } from './helpers/constants';
 import {
@@ -118,29 +119,29 @@ programCommand('upload')
       secretKey: ipfsInfuraSecret,
     };
 
-    const pngFileCount = files.filter(it => {
-      return it.endsWith(EXTENSION_PNG);
+    const imageCount = files.filter(it => {
+      return it.endsWith(EXTENSION_PNG) || it.endsWith(EXTENSION_GIF);
     }).length;
     const jsonFileCount = files.filter(it => {
       return it.endsWith(EXTENSION_JSON);
     }).length;
 
     const parsedNumber = parseInt(number);
-    const elemCount = parsedNumber ? parsedNumber : pngFileCount;
+    const elemCount = parsedNumber ? parsedNumber : imageCount;
 
-    if (pngFileCount !== jsonFileCount) {
+    if (imageCount !== jsonFileCount) {
       throw new Error(
-        `number of png files (${pngFileCount}) is different than the number of json files (${jsonFileCount})`,
+        `number of png files (${imageCount}) is different than the number of json files (${jsonFileCount})`,
       );
     }
 
-    if (elemCount < pngFileCount) {
+    if (elemCount < imageCount) {
       throw new Error(
-        `max number (${elemCount})cannot be smaller than the number of elements in the source folder (${pngFileCount})`,
+        `max number (${elemCount})cannot be smaller than the number of elements in the source folder (${imageCount})`,
       );
     }
 
-    log.info(`Beginning the upload for ${elemCount} (png+json) pairs`);
+    log.info(`Beginning the upload for ${elemCount} (image+json) pairs`);
 
     const startMs = Date.now();
     log.info('started at: ' + startMs.toString());

--- a/js/packages/cli/src/commands/upload.ts
+++ b/js/packages/cli/src/commands/upload.ts
@@ -110,11 +110,12 @@ export async function upload(
               log.info(`Processing file: ${i}, ${imageName}`);
             }
             const manifestPath = image.replace(imageExtension, EXTENSION_JSON);
+			const imageFileName = `image${imageExtension}`;
             const manifestContent = fs
               .readFileSync(manifestPath)
               .toString()
-              .replace(imageName, 'image.png')
-              .replace(imageName, 'image.png');
+              .replace(imageName, imageFileName)
+              .replace(imageName, imageFileName);
             const manifest = JSON.parse(manifestContent);
 
             const manifestBuffer = Buffer.from(JSON.stringify(manifest));

--- a/js/packages/cli/src/helpers/cache.ts
+++ b/js/packages/cli/src/helpers/cache.ts
@@ -16,9 +16,11 @@ export function loadCache(
   cPath: string = CACHE_PATH,
 ) {
   const path = cachePath(env, cacheName, cPath);
-  return fs.existsSync(path)
+  const cacheContent = fs.existsSync(path)
     ? JSON.parse(fs.readFileSync(path).toString())
     : undefined;
+	// console.log(`LOADED CACHE CONTENT: ${JSON.stringify(cacheContent)}`);
+	return cacheContent;
 }
 
 export function saveCache(
@@ -29,6 +31,7 @@ export function saveCache(
 ) {
   cacheContent.env = env;
   cacheContent.cacheName = cacheName;
+//   console.log(`SAVING CACHE: ${JSON.stringify(cacheContent)}`);
   fs.writeFileSync(
     cachePath(env, cacheName, cPath),
     JSON.stringify(cacheContent),

--- a/js/packages/cli/src/helpers/constants.ts
+++ b/js/packages/cli/src/helpers/constants.ts
@@ -67,3 +67,4 @@ export const DEFAULT_TIMEOUT = 15000;
 
 export const EXTENSION_PNG = '.png';
 export const EXTENSION_JSON = '.json';
+export const EXTENSION_GIF = '.gif';

--- a/js/packages/cli/src/helpers/upload/arweave.ts
+++ b/js/packages/cli/src/helpers/upload/arweave.ts
@@ -50,6 +50,7 @@ function estimateManifestSize(filenames: string[]) {
   };
 
   const data = Buffer.from(JSON.stringify(manifest), 'utf8');
+  console.log(`ARWEAVE MANIFEST: ${data}`);
   log.debug('Estimated manifest size:', data.length);
   return data.length;
 }
@@ -102,11 +103,23 @@ export async function arweaveUpload(
   });
   data.append('file[]', manifestBuffer, 'metadata.json');
 
+  console.log(data);
+  manifest["image"] = manifest["image"].replace('.png', imageExtension);
+  manifest["properties"]["files"] = {
+    uri: `image${imageExtension}`,
+	type: `image/${imageExtension.replace('.', '')}`
+  };
+  console.log(data["_streams"].DelayedStream);
+  console.log(manifest["properties"]["files"]);
+  console.log(manifest);
+  console.log(index);
   const result = await upload(data, manifest, index);
 
   const metadataFile = result.messages?.find(
     m => m.filename === 'manifest.json',
   );
+  // THIS MIGHT BE FUCKED
+  //MIGHT NEED TO BE HARDCODED TO BE PNG
   const imageFile = result.messages?.find(
     m => m.filename === `image${imageExtension}`,
   );

--- a/js/packages/cli/src/helpers/upload/arweave.ts
+++ b/js/packages/cli/src/helpers/upload/arweave.ts
@@ -107,8 +107,6 @@ export async function arweaveUpload(
   const metadataFile = result.messages?.find(
     m => m.filename === 'manifest.json',
   );
-  // THIS MIGHT BE FUCKED
-  //MIGHT NEED TO BE HARDCODED TO BE PNG
   const imageFile = result.messages?.find(
     m => m.filename === `image${imageExtension}`,
   );

--- a/js/packages/cli/src/helpers/upload/arweave.ts
+++ b/js/packages/cli/src/helpers/upload/arweave.ts
@@ -64,8 +64,9 @@ export async function arweaveUpload(
   index,
 ) {
   const fsStat = await stat(image);
+  const imageExtension = path.extname(image);
   const estimatedManifestSize = estimateManifestSize([
-    'image.png',
+    `image${imageExtension}`,
     'metadata.json',
   ]);
   const storageCost = await fetchAssetCostToStore([
@@ -96,8 +97,8 @@ export async function arweaveUpload(
   data.append('transaction', tx['txid']);
   data.append('env', env);
   data.append('file[]', fs.createReadStream(image), {
-    filename: `image.png`,
-    contentType: 'image/png',
+    filename: `image${imageExtension}`,
+    contentType: `image/${imageExtension.replace('.', '')}`,
   });
   data.append('file[]', manifestBuffer, 'metadata.json');
 
@@ -106,12 +107,14 @@ export async function arweaveUpload(
   const metadataFile = result.messages?.find(
     m => m.filename === 'manifest.json',
   );
+  // THIS MIGHT BE FUCKED
+  //MIGHT NEED TO BE HARDCODED TO BE PNG
   const imageFile = result.messages?.find(
-    m => m.filename === 'image.png',
+    m => m.filename === `image${imageExtension}`,
   );
   if (metadataFile?.transactionId) {
     const link = `https://arweave.net/${metadataFile.transactionId}`;
-    const imageLink = `https://arweave.net/${imageFile.transactionId}?ext=png`;
+    const imageLink = `https://arweave.net/${imageFile.transactionId}?ext=${imageExtension.replace('.', '')}`;
     log.debug(`File uploaded: ${link}`);
     return [link, imageLink];
   } else {


### PR DESCRIPTION
I needed it for my project, so I figured I would investigate why the image had to be PNG to work with the candy-machine-cli script
turns out it doesn't have to be, it was just hardcoded to only take png, so I fixed that.