### PR TITLE
Fix Generative Traits Configuration Generator

### DIFF
--- a/js/packages/cli/src/commands/generateConfigurations.ts
+++ b/js/packages/cli/src/commands/generateConfigurations.ts
@@ -14,6 +14,8 @@ export async function generateConfigurations(
     symbol: '',
     description: '',
     creators: [],
+    dnp: {},
+    premadeCustoms: [],
     collection: {},
     breakdown: {},
     order: traits,
@@ -29,7 +31,7 @@ export async function generateConfigurations(
         const tmp = {};
 
         attributes.forEach((attr, i) => {
-          tmp[attr] = randoms[i] / 100;
+          tmp[attr] = randoms[i];
         });
 
         configs['breakdown'][trait] = tmp;


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

After some of the recent updates to the candy machine traits, the traits configuration generator no longer generates a valid configuration file.

The new requirements are:
1. Rarity values are expected to sum up to 100 instead of 1 now
2. `dnp` and `premadeCustoms` attributes were added and expected but are not generated.

Without the correct rarity values, the following error is returned:
```shell
Loaded configuration file
{
  'cyan-face.png': 0.07,
  'dark-green-face.png': 0.04,
  'flesh-face.png': 0.03,
  'gold-face.png': 0.11,
  'grapefruit-face.png': 0.07,
  'green-face.png': 0.05,
  'pink-face.png': 0.05,
  'purple-face.png': 0.02,
  'sun-face.png': 0.1,
  'teal-face.png': 0.46
}
(node:19642) UnhandledPromiseRejectionWarning: Error: Breakdown not within 1% of 100! It is: 1
```

Without the new attributes `dnp` and `premadeCustoms`, you get an error like the following:
```shell
Loaded configuration file
(node:19430) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'length' of undefined
```

## References

_List links to any related tasks (GitHub Issues, Pull Requests, 3rd part task managers)_

## Testing

_How was this tested? If manually tested, list all steps necessary for the reviewer to confirm._

Perform the following steps from your terminal, do the following:
1. `cd js`
2. `yarn install`
3. `yarn build`
4. `cp -r packages/cli/example-traits ./traits`
5. `node packages/cli/build/candy-machine-cli.js generate_art_configurations ./traits`
6. ` node packages/cli/build/candy-machine-cli.js create_generative_art ./traits -c ./traits-configuration.json -n 100`