### PR TITLE
chore: silence incorrect warning for token metadata

### DIFF
--- a/rust/token-metadata/program/tests/utils/mod.rs
+++ b/rust/token-metadata/program/tests/utils/mod.rs
@@ -1,3 +1,5 @@
+// NOTE: cargo test-bpf results in lots of incorrect dead code warnings inside these test/utils
+#![allow(dead_code)]
 mod assert;
 mod edition_marker;
 mod external_price;


### PR DESCRIPTION
When running `cargo test-bpf` for the `token-metadata` program lots of _dead code_ warnings are printed for test utils which is incorrect as it is in use by the tests.

I tried different ways to fix this, but the only way to silence this for now is via a pragma.