### PR TITLE
gh actions: always run required workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,12 +3,8 @@ name: Lint JavaScript
 on:
   push:
     branches: [master]
-    paths:
-      - 'js/**'
   pull_request:
     branches: [master]
-    paths:
-      - 'js/**'
 
 jobs:
   eslint:

--- a/.github/workflows/yarn-and-test-cli.yml
+++ b/.github/workflows/yarn-and-test-cli.yml
@@ -1,14 +1,10 @@
-name: Yarn Install and Test JS
+name: Yarn Install and Test CandyMachine
 
 on:
   push:
     branches: [master]
-    paths:
-      - 'js/**'
   pull_request:
     branches: [master]
-    paths:
-      - 'js/**'
 
 jobs:
   unit_tests:


### PR DESCRIPTION
Otherwise pull requests become stuck when the workflow does not run but is
configured as required.