### PR TITLE
github: add build workflow

### DIFF
--- a/.github/workflows/yarn-build.yml
+++ b/.github/workflows/yarn-build.yml
@@ -1,0 +1,26 @@
+name: Yarn build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+
+      - uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install modules
+        run: yarn install
+        working-directory: js
+
+      - name: Build all packages
+        run: yarn build
+        working-directory: js

--- a/js/package.json
+++ b/js/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "bootstrap": "lerna link && lerna bootstrap",
     "build": "lerna run build",
-    "build-CI-without-gumdrop": "lerna run build --ignore gumdrop",
+    "build-web": "lerna run build --stream --scope @oyster/common --scope web",
     "start": "cross-env CI=true lerna run start --scope @oyster/common --stream --parallel --scope web",
     "lint": "prettier -c 'packages/*/{src,test}/**/*.ts' && npm run lint:eslint",
     "lint:eslint": "eslint 'packages/*/{src,test}/**/*.ts'",


### PR DESCRIPTION
Triggers `yarn install` and `build` from the `js` directory which triggers a build in all packages.

This replaces the current [Vercel metaplex-web CI step](https://vercel.com/metaplex/metaplex-web) which runs out of memory on Vercel.

With this new workflow we can remove the `build-CI-without-gumdrop` package.json script currently used by the Vercel job.

