### PR TITLE
fix: Prevent number of hooks from changing in user badge component

### DIFF
--- a/js/packages/web/src/components/CurrentUserBadge/index.tsx
+++ b/js/packages/web/src/components/CurrentUserBadge/index.tsx
@@ -209,13 +209,14 @@ export const CurrentUserBadge = (props: {
   const { account } = useNativeAccount();
   const solPrice = useSolPrice();
   const [showAddFundsModal, setShowAddFundsModal] = useState<Boolean>(false);
+  const tokenList = useTokenList();
 
   if (!wallet || !publicKey) {
     return null;
   }
   const balance = (account?.lamports || 0) / LAMPORTS_PER_SOL;
   const balanceInUSD = balance * solPrice;
-  const solMintInfo = useTokenList().tokenMap.get(WRAPPED_SOL_MINT.toString());
+  const solMintInfo = tokenList.tokenMap.get(WRAPPED_SOL_MINT.toString());
   const iconStyle: React.CSSProperties = {
     display: 'flex',
     width: props.iconSize,


### PR DESCRIPTION
The number and call order of hooks in React components has to be the same from render to render. We had a situation in the user badge component where we'd return early before calling the `useTokenList()` hook.

That led to this error:

```
Warning: React has detected a change in the order of Hooks called by CurrentUserBadge. This will lead to bugs and errors if not fixed. For more information, read the Rules of Hooks: https://reactjs.org/link/rules-of-hooks
```

This PR fixes that. We might also consider turning on the React hooks linter (add `'plugin:react-hooks/recommended'` to the eslintrc) which would have warned about this like so:

<img width="811" alt="image" src="https://user-images.githubusercontent.com/13243/143990611-39863be8-6ca4-402e-b769-7f9ff8c16d9e.png">

Before we consider doing that, we should probably clean up the rest of the lint that's snuck into React components. See #1076.