### PR TITLE
fix: Prevent wallet errors from bubbling up to the default error handler

### DIFF
--- a/js/packages/web/src/components/AuctionCard/index.tsx
+++ b/js/packages/web/src/components/AuctionCard/index.tsx
@@ -211,7 +211,7 @@ export const AuctionCard = ({
   const wallet = useWallet();
   const { setVisible } = useWalletModal();
   const connect = useCallback(
-    () => (wallet.wallet ? wallet.connect().catch() : setVisible(true)),
+    () => (wallet.wallet ? wallet.connect().catch(() => {}) : setVisible(true)),
     [wallet.wallet, wallet.connect, setVisible],
   );
 

--- a/js/packages/web/src/views/admin/index.tsx
+++ b/js/packages/web/src/views/admin/index.tsx
@@ -46,7 +46,7 @@ export const AdminView = () => {
   const wallet = useWallet();
   const { setVisible } = useWalletModal();
   const connect = useCallback(
-    () => (wallet.wallet ? wallet.connect().catch() : setVisible(true)),
+    () => (wallet.wallet ? wallet.connect().catch(() => {}) : setVisible(true)),
     [wallet.wallet, wallet.connect, setVisible],
   );
   const { storeAddress, setStoreForOwner, isConfigured } = useStore();

--- a/js/packages/web/src/views/home/setup.tsx
+++ b/js/packages/web/src/views/home/setup.tsx
@@ -21,7 +21,7 @@ export const SetupView = () => {
   const wallet = useWallet();
   const { setVisible } = useWalletModal();
   const connect = useCallback(
-    () => (wallet.wallet ? wallet.connect().catch() : setVisible(true)),
+    () => (wallet.wallet ? wallet.connect().catch(() => {}) : setVisible(true)),
     [wallet.wallet, wallet.connect, setVisible],
   );
   const [storeAddress, setStoreAddress] = useState<string | undefined>();


### PR DESCRIPTION
Before, if you rejected a wallet authorization in dev mode you would see the error bubble all the way up to Next's error handler.

![bad](https://user-images.githubusercontent.com/13243/144006541-ebea5442-07b0-4ca9-b89c-e66b6fb50953.jpg)

After this PR, you and your users both see the toast, but you, the dev, otherwise don't see a redbox.

![good](https://user-images.githubusercontent.com/13243/144006599-d94c7ab0-f0ec-4509-98d5-4d28d2aed960.jpg)


