### PR TITLE
enhancement: Fetch the token list once on startup; save folks 200K

### DIFF
--- a/js/packages/common/src/contexts/connection.tsx
+++ b/js/packages/common/src/contexts/connection.tsx
@@ -1,9 +1,6 @@
 import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
-import {
-  TokenInfo,
-  TokenListProvider,
-  ENV as ChainId,
-} from '@solana/spl-token-registry';
+import { getTokenListContainerPromise } from '../utils';
+import { TokenInfo, ENV as ChainId } from '@solana/spl-token-registry';
 import { WalletNotConnectedError } from '@solana/wallet-adapter-base';
 import {
   Keypair,
@@ -108,7 +105,7 @@ export function ConnectionProvider({ children }: { children: any }) {
 
   useEffect(() => {
     function fetchTokens() {
-      return new TokenListProvider().resolve().then(container => {
+      return getTokenListContainerPromise().then(container => {
         const list = container
           .excludeByTag('nft')
           .filterByChainId(endpoint.chainId)

--- a/js/packages/common/src/utils/getTokenListContainerPromise.ts
+++ b/js/packages/common/src/utils/getTokenListContainerPromise.ts
@@ -1,0 +1,13 @@
+import {
+  TokenListContainer,
+  TokenListProvider,
+} from '@solana/spl-token-registry';
+
+let _cachedTokenListContainerPromise: Promise<TokenListContainer> | null;
+
+export function getTokenListContainerPromise() {
+  if (_cachedTokenListContainerPromise == null) {
+    _cachedTokenListContainerPromise = new TokenListProvider().resolve();
+  }
+  return _cachedTokenListContainerPromise;
+}

--- a/js/packages/common/src/utils/index.tsx
+++ b/js/packages/common/src/utils/index.tsx
@@ -11,3 +11,4 @@ export * from './isValidHttpUrl';
 export * from './borsh';
 export * from './createPipelineExecutor';
 export * from './assets';
+export * from './getTokenListContainerPromise';

--- a/js/packages/gumdrop/src/contexts/ConnectionContext.tsx
+++ b/js/packages/gumdrop/src/contexts/ConnectionContext.tsx
@@ -1,4 +1,7 @@
-import { useLocalStorageState } from "@oyster/common";
+import {
+  getTokenListContainerPromise,
+  useLocalStorageState,
+} from '@oyster/common';
 import {
   Keypair,
   Commitment,
@@ -14,7 +17,6 @@ import {
 } from "../utils/transactions";
 import {
   TokenInfo,
-  TokenListProvider,
   ENV as ChainId,
 } from "@solana/spl-token-registry";
 import { WalletSigner } from "./WalletContext/WalletContext";
@@ -79,7 +81,7 @@ export function ConnectionProvider({ children = undefined } : { children : React
   const [tokenMap, setTokenMap] = useState<Map<string, TokenInfo>>(new Map());
   useEffect(() => {
     // fetch token files
-    new TokenListProvider().resolve().then((container) => {
+    getTokenListContainerPromise().then((container) => {
       const list = container
         .excludeByTag("nft")
         .filterByChainId(

--- a/js/packages/web/src/contexts/tokenList.tsx
+++ b/js/packages/web/src/contexts/tokenList.tsx
@@ -34,7 +34,7 @@ export function SPLTokenListProvider({ children = null as any }) {
     ]: [WRAPPED_SOL_MINT]
 
   useEffect(() => {
-    getTokenListContainerPromise().then(setTokenList);
+    getTokenListContainerPromise().then(()=>setTokenList);
   }, [setTokenList]);
 
   const hasOtherTokens = !!process.env.NEXT_SPL_TOKEN_MINTS;

--- a/js/packages/web/src/contexts/tokenList.tsx
+++ b/js/packages/web/src/contexts/tokenList.tsx
@@ -1,9 +1,6 @@
 import React, { useContext, useEffect, useMemo, useState } from 'react';
-import {
-  TokenInfo,
-  TokenListContainer,
-  TokenListProvider,
-} from "@solana/spl-token-registry";
+import { getTokenListContainerPromise } from '@oyster/common';
+import { TokenInfo, TokenListContainer } from "@solana/spl-token-registry";
 import { WRAPPED_SOL_MINT } from '@project-serum/serum/lib/token-instructions';
 
 // Tag in the spl-token-registry for sollet wrapped tokens.
@@ -37,7 +34,7 @@ export function SPLTokenListProvider({ children = null as any }) {
     ]: [WRAPPED_SOL_MINT]
 
   useEffect(() => {
-    new TokenListProvider().resolve().then(setTokenList);
+    getTokenListContainerPromise().then(setTokenList);
   }, [setTokenList]);
 
   const hasOtherTokens = !!process.env.NEXT_SPL_TOKEN_MINTS;


### PR DESCRIPTION
Every time that you call `TokenListProvider.resolve()` a new network fetch for the token list is made. We've been fetching two identical copies of the token list on startup!

In this PR, we create a singleton that everyone can share. The first consumer causes the token list to be fetched, and then every consumer after uses the cached result. This saves folks from having to download about 200K on startup.

Before:

<img width="719" alt="image" src="https://user-images.githubusercontent.com/13243/144204453-69db604b-3c29-4f31-b64c-ab9d75a55447.png">

After:

<img width="719" alt="image" src="https://user-images.githubusercontent.com/13243/144204305-b46635b3-ad76-42a2-a083-346b04556ef0.png">
