### PR TITLE
fix: fixed fully opened pack

### DIFF
--- a/js/packages/web/src/components/PackCard/index.tsx
+++ b/js/packages/web/src/components/PackCard/index.tsx
@@ -38,7 +38,10 @@ const PackCard = ({
   const canBeReveal = allowedAmountToRedeem && cardsRedeemed ?
     allowedAmountToRedeem - cardsRedeemed : allowedAmountToRedeem || 0;
 
-  const infoMessageTitle = artView ? `${canBeReveal} NFT reveal left` : 'PACK OPENING UNLOCKS';
+  const showInfoMessage = () => {
+    if (!artView) return 'PACK OPENING UNLOCKS';
+    return canBeReveal ? `${canBeReveal} NFT reveal left` : 'All revealed';
+  }
 
   const showBadge = useCallback(() => {
     switch (art.type) {
@@ -69,7 +72,7 @@ const PackCard = ({
         <div className="art-auction-info">
           <div className="art-auction-info__left-side">
             <img src="/grid-4.svg" />
-            <span className="info-message">{infoMessageTitle}</span>
+            <span className="info-message">{showInfoMessage()}</span>
           </div>
           <div className="art-auction-info__right-side">
             <span>{headingTitle}</span>

--- a/js/packages/web/src/components/PackCard/index.tsx
+++ b/js/packages/web/src/components/PackCard/index.tsx
@@ -35,13 +35,13 @@ const PackCard = ({
 
   const packStatusTitle = cardsRedeemed ? 'Opened' : 'Sealed';
   const headingTitle = artView ? packStatusTitle : 'Pack';
-  const canBeReveal = allowedAmountToRedeem && cardsRedeemed ?
+  const numberOfCardsLeft = allowedAmountToRedeem && cardsRedeemed ?
     allowedAmountToRedeem - cardsRedeemed : allowedAmountToRedeem || 0;
 
-  const showInfoMessage = () => {
-    if (!artView) return 'PACK OPENING UNLOCKS';
-    return canBeReveal ? `${canBeReveal} NFT reveal left` : 'All revealed';
-  }
+  const infoMessage = useMemo(() => {
+      if (!artView) return 'PACK OPENING UNLOCKS';
+      return numberOfCardsLeft ? `${numberOfCardsLeft} NFT reveal left` : 'All revealed';
+  }, [artView, numberOfCardsLeft]);
 
   const showBadge = useCallback(() => {
     switch (art.type) {
@@ -72,7 +72,7 @@ const PackCard = ({
         <div className="art-auction-info">
           <div className="art-auction-info__left-side">
             <img src="/grid-4.svg" />
-            <span className="info-message">{showInfoMessage()}</span>
+            <span className="info-message">{infoMessage}</span>
           </div>
           <div className="art-auction-info__right-side">
             <span>{headingTitle}</span>

--- a/js/packages/web/src/views/pack/components/PackSidebar/index.tsx
+++ b/js/packages/web/src/views/pack/components/PackSidebar/index.tsx
@@ -15,13 +15,13 @@ interface IPropsPackSidebar {
 }
 
 const PackSidebar = ({ onOpenPack }: IPropsPackSidebar) => {
-  const { pack, voucherMetadataKey, cardsRedeemed } = usePack();
+  const { pack, voucherMetadataKey, provingProcess } = usePack();
 
   const metadataPubkey = voucherMetadataKey || '';
   const art = useArt(metadataPubkey);
   const { publicKey } = useWallet();
   const userWallet = pubkeyToString(publicKey);
-  const canOpen = pack?.info.allowedAmountToRedeem !== cardsRedeemed;
+  const isExhausted = provingProcess?.info.isExhausted;
 
   return (
     <div className="pack-view__sidebar">
@@ -71,7 +71,7 @@ const PackSidebar = ({ onOpenPack }: IPropsPackSidebar) => {
       </div>
       <Divider className="divider" />
       {
-        canOpen && <OpenPackButton onClick={onOpenPack} />
+        !isExhausted && <OpenPackButton onClick={onOpenPack} />
       }
       <Divider className="divider"/>
       <div className="pack-view__description-block">

--- a/js/packages/web/src/views/pack/components/PackSidebar/index.tsx
+++ b/js/packages/web/src/views/pack/components/PackSidebar/index.tsx
@@ -15,12 +15,13 @@ interface IPropsPackSidebar {
 }
 
 const PackSidebar = ({ onOpenPack }: IPropsPackSidebar) => {
-  const { pack, voucherMetadataKey } = usePack();
+  const { pack, voucherMetadataKey, cardsRedeemed } = usePack();
 
   const metadataPubkey = voucherMetadataKey || '';
   const art = useArt(metadataPubkey);
   const { publicKey } = useWallet();
   const userWallet = pubkeyToString(publicKey);
+  const canOpen = pack?.info.allowedAmountToRedeem !== cardsRedeemed;
 
   return (
     <div className="pack-view__sidebar">
@@ -69,7 +70,9 @@ const PackSidebar = ({ onOpenPack }: IPropsPackSidebar) => {
         </div>
       </div>
       <Divider className="divider" />
-      <OpenPackButton onClick={onOpenPack} />
+      {
+        canOpen && <OpenPackButton onClick={onOpenPack} />
+      }
       <Divider className="divider"/>
       <div className="pack-view__description-block">
         <p className="pack-view__title">DETAILS</p>

--- a/js/packages/web/src/views/pack/contexts/PackContext.tsx
+++ b/js/packages/web/src/views/pack/contexts/PackContext.tsx
@@ -7,6 +7,7 @@ import {
   getSearchParams,
 } from '@oyster/common';
 import { PackSet } from '@oyster/common/dist/lib/models/packs/accounts/PackSet';
+import { ProvingProcess } from '@oyster/common/dist/lib/models/packs/accounts/ProvingProcess';
 import { useWallet } from '@solana/wallet-adapter-react';
 import React, { useContext, useEffect, useMemo, useState } from 'react';
 import { useParams, useLocation } from 'react-router';
@@ -21,6 +22,7 @@ import {
 import { useOpenedMetadata } from '../hooks/useOpenedMetadata';
 
 type PackContextProps = {
+  provingProcess?: ParsedAccount<ProvingProcess>,
   isLoading: boolean;
   packKey: StringPublicKey;
   voucherEditionKey: StringPublicKey;
@@ -34,6 +36,7 @@ type PackContextProps = {
 };
 
 export const PackContext = React.createContext<PackContextProps>({
+  provingProcess: undefined,
   isLoading: false,
   packKey: '',
   voucherEditionKey: '',
@@ -111,6 +114,7 @@ export const PackProvider: React.FC = ({ children }) => {
   return (
     <PackContext.Provider
       value={{
+        provingProcess,
         isLoading,
         packKey,
         voucherEditionKey,

--- a/js/packages/web/src/views/pack/contexts/PackContext.tsx
+++ b/js/packages/web/src/views/pack/contexts/PackContext.tsx
@@ -36,7 +36,6 @@ type PackContextProps = {
 };
 
 export const PackContext = React.createContext<PackContextProps>({
-  provingProcess: undefined,
   isLoading: false,
   packKey: '',
   voucherEditionKey: '',


### PR DESCRIPTION
Task: https://app.asana.com/0/1201289799176936/1201474518265519
To-Do:
• For fully opened packs we shouldn't show "Resume opening pack" button
• For fully opened packs we should show "All revealed" at My Items instead of "0 attempts left"

Result:
<img width="1427" alt="Снимок экрана 2021-12-07 в 16 42 24" src="https://user-images.githubusercontent.com/69786983/145041249-48111af3-2166-48a0-a5fc-e43e13524c39.png">
<img width="359" alt="Снимок экрана 2021-12-07 в 16 42 59" src="https://user-images.githubusercontent.com/69786983/145041306-e647c973-6275-4fc6-9066-957d8273b107.png">

