### PR TITLE
fix duplicate declaration of randomOracle

### DIFF
--- a/js/packages/web/src/views/pack/transactions/interface.ts
+++ b/js/packages/web/src/views/pack/transactions/interface.ts
@@ -58,7 +58,6 @@ export interface RequestCardParams {
   tokenAccount: StringPublicKey;
   packVoucher: StringPublicKey;
   wallet: WalletContextState;
-  randomOracle: StringPublicKey;
 }
 
 export interface RequestCardsParams {


### PR DESCRIPTION
The duplicate declaration of  `randomOracle: StringPublicKey;` is causing issues with yarn build

image from discord with error:
https://media.discordapp.net/attachments/915387242590113803/918150617724231770/EC86DEDD-CCFD-48B3-887F-80D41A49B870.jpg?width=1207&height=905