### PR TITLE
fix: packs cards badges

### DIFF
--- a/js/packages/web/src/components/PackCard/index.tsx
+++ b/js/packages/web/src/components/PackCard/index.tsx
@@ -37,21 +37,18 @@ const PackCard = ({
 
   const packStatusTitle = cardsRedeemed ? 'Opened' : 'Sealed';
   const headingTitle = artView ? packStatusTitle : 'Pack';
-  const numberOfCardsLeft = allowedAmountToRedeem && cardsRedeemed ?
-    allowedAmountToRedeem - cardsRedeemed : allowedAmountToRedeem || 0;
+  const badge = art.type === ArtType.Print && `${art.edition} of ${art.supply}`;
+  const numberOfCardsLeft =
+    allowedAmountToRedeem && cardsRedeemed
+      ? allowedAmountToRedeem - cardsRedeemed
+      : allowedAmountToRedeem || 0;
 
   const infoMessage = useMemo(() => {
-      if (!artView) return 'PACK OPENING UNLOCKS';
-      return numberOfCardsLeft ? `${numberOfCardsLeft} NFT reveal left` : 'All revealed';
+    if (!artView) return 'PACK OPENING UNLOCKS';
+    return numberOfCardsLeft
+      ? `${numberOfCardsLeft} NFT reveal left`
+      : 'All revealed';
   }, [artView, numberOfCardsLeft]);
-
-  const showBadge = useCallback(() => {
-    switch (art.type) {
-      case ArtType.NFT: return 'Unique';
-      case ArtType.Master: return 'NFT 0';
-      case ArtType.Print: return `${art.edition} of ${art.supply}`;
-     }
-  }, [art])
 
   return (
     <Card hoverable className="auction-render-card" bordered={false}>
@@ -73,11 +70,15 @@ const PackCard = ({
           <div className="card-artist-info card-artist-info--pack">
             <div className="pack-creator-info">
               <MetaAvatar creators={[creator]} />
-              <span className="pack-creator-name">{creator.name || shortenAddress(creator?.address || '')}</span>
+              <span className="pack-creator-name">
+                {creator.name || shortenAddress(creator?.address || '')}
+              </span>
             </div>
-            <div className="card-artist-info__subtitle">
-              <p className="info-message__main">{showBadge()}</p>
-            </div>
+            {badge && (
+              <div className="card-artist-info__subtitle">
+                <p className="info-message__main">{badge}</p>
+              </div>
+            )}
           </div>
           <div className="art-content-wrapper">
             <ArtContent pubkey={voucherMetadata} preview={false} />
@@ -94,7 +95,7 @@ const PackCard = ({
           </div>
         </div>
       </div>
-      {!artView && <div className="card-bid-info"/>}
+      {!artView && <div className="card-bid-info" />}
     </Card>
   );
 };

--- a/js/packages/web/src/views/artworks/hooks/useUserMetadataWithPacks.ts
+++ b/js/packages/web/src/views/artworks/hooks/useUserMetadataWithPacks.ts
@@ -62,7 +62,7 @@ const getMetadataWithPacks = ({
       {
         ...packs[voucher.info.packSet],
         voucher: voucher.pubkey,
-        voucherMetadataKey: voucher.info.metadata,
+        voucherMetadataKey: metadata.metadata.pubkey,
         edition: metadata.edition.pubkey,
       },
     ];


### PR DESCRIPTION
### Description

This PR fix pack cards badges in the My Items section.

* Show correct edition of voucher for pack card
* Hide edition number badge if the pack was opened

### Screenshots

![Screenshot from 2021-12-11 12-26-16](https://user-images.githubusercontent.com/9057096/145673367-24518f1a-8867-424b-8de3-de21c938269d.png)
![Screenshot from 2021-12-11 12-26-01](https://user-images.githubusercontent.com/9057096/145673370-32de9def-0a3e-4521-a0df-8a1481448fba.png)


