### PR TITLE
feat: Hide NFTs in background while pack is opened

### DIFF
--- a/js/packages/web/src/views/pack/components/ArtCard/index.tsx
+++ b/js/packages/web/src/views/pack/components/ArtCard/index.tsx
@@ -4,7 +4,12 @@ import { Link } from 'react-router-dom';
 import { usePack } from '../../contexts/PackContext';
 import SmallLoader from '../../../../components/SmallLoader';
 
-const ArtCard = ({ index }: { index: number }) => {
+interface ArtCardProps {
+  index: number;
+  isModalOpened: boolean;
+}
+
+const ArtCard = ({ index, isModalOpened }: ArtCardProps) => {
   const { openedMetadata, provingProcess } = usePack();
   const cardsRedeemed = provingProcess?.info.cardsRedeemed || 0;
 
@@ -18,7 +23,7 @@ const ArtCard = ({ index }: { index: number }) => {
     backgroundImage: `url(${data?.image})`,
   };
 
-  const shouldRenderImage = isOpenedCard && pubkey;
+  const shouldRenderImage = !isModalOpened && isOpenedCard && pubkey;
 
   return (
     <div className="pack-card" ref={ref}>

--- a/js/packages/web/src/views/pack/contexts/PackContext.tsx
+++ b/js/packages/web/src/views/pack/contexts/PackContext.tsx
@@ -140,6 +140,8 @@ export const PackProvider: React.FC = ({ children }) => {
   const handleFetch = async () => {
     setIsLoading(true);
 
+    setRedeemModalMetadata([]);
+
     await pullPackPage(userAccounts, packKey);
 
     const initialProvingProcess = getInitialProvingProcess({
@@ -150,6 +152,8 @@ export const PackProvider: React.FC = ({ children }) => {
 
     if (initialProvingProcess) {
       setProvingProcess(initialProvingProcess);
+    } else {
+      setProvingProcess(undefined);
     }
 
     setIsLoading(false);

--- a/js/packages/web/src/views/pack/index.tsx
+++ b/js/packages/web/src/views/pack/index.tsx
@@ -26,9 +26,9 @@ const PackView: React.FC = () => {
       <Row>
         <Col md={16}>
           <div className="pack-view__list">
-            {cards.map(index => {
-              return <ArtCard key={index} index={index} />;
-            })}
+            {cards.map(index => (
+              <ArtCard key={index} index={index} isModalOpened={openModal} />
+            ))}
           </div>
         </Col>
         <Col md={8} className="pack-view__sidebar-container">


### PR DESCRIPTION
### Description

This PR hides opened NFTs while redeem modal is opened. 

### Screenshots

![Screenshot from 2021-12-11 12-40-49](https://user-images.githubusercontent.com/9057096/145673638-1f59edad-4bd2-4fd9-a3c5-d299a2cdfdb5.png)

