### PR TITLE
fix: issue use candy-machine-cli upload error "assets/0.json.json"

### DIFF
--- a/js/packages/cli/src/commands/upload.ts
+++ b/js/packages/cli/src/commands/upload.ts
@@ -363,7 +363,7 @@ export async function upload({
               );
               const manifest = getAssetManifest(
                 dirname,
-                `${assetKey.index}.json`,
+                `${assetKey.index}`,
               );
               const manifestBuffer = Buffer.from(JSON.stringify(manifest));
               if (i >= lastPrinted + tick || i === 0) {


### PR DESCRIPTION
**Description**
When use candy-machine-cli upload is showing an error "assets/0.json.json" like this

![alt text](https://assets.me-idea.in.th/error.png)


like a problem  - #1190