### PR TITLE
added fix for json.json error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ docs/lockup-ui/
 .DS_Store
 *~
 .idea
-assets
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ docs/lockup-ui/
 .DS_Store
 *~
 .idea
+assets
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/js/packages/cli/src/commands/upload.ts
+++ b/js/packages/cli/src/commands/upload.ts
@@ -1,4 +1,3 @@
-
 import fs from 'fs';
 import { readFile } from 'fs/promises';
 import path from 'path';
@@ -91,10 +90,12 @@ function getAssetKeysNeedingUpload(
  * or do not truthy value for the `link` property.
  */
 function getAssetManifest(dirname: string, assetKey: string): Manifest {
-  const manifestPath = path.join(dirname, `${assetKey}.json`);
+  const manifestPath = path.join(
+    dirname,
+    assetKey.includes('json') ? assetKey : `${assetKey}.json`,
+  );
   return JSON.parse(fs.readFileSync(manifestPath).toString());
 }
-
 
 /**
  * Initialize & deploy the Candy Machine Custom Program's configuration,
@@ -363,7 +364,9 @@ export async function upload({
               );
               const manifest = getAssetManifest(
                 dirname,
-                `${assetKey.index}.json`,
+                assetKey.index.includes('json')
+                  ? assetKey.index
+                  : `${assetKey.index}.json`,
               );
               const manifestBuffer = Buffer.from(JSON.stringify(manifest));
               if (i >= lastPrinted + tick || i === 0) {


### PR DESCRIPTION
Fix for https://github.com/metaplex-foundation/metaplex/issues/1190

```
ts-node js/packages/cli/src/candy-machine-cli.ts upload ./assets --env devnet --storage arweave --keypair ~/.config/solana/devnet-test.json
```

This command was causing issues for some json files and was throwing the following error : 
```
upload was not successful, please re-run. Error: ENOENT: no such file or directory, open 'assets\0.json.json'
```
I tried removing the hardcoded json as a whole from the upload.ts file, then it was working. But then again that might break something that was working initially with the hardcoded value, so kept the fix conditional depending upon the file name.
