### PR TITLE
fix: use pack uri

### DIFF
--- a/js/packages/web/src/components/PackCard/index.tsx
+++ b/js/packages/web/src/components/PackCard/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useCallback, useMemo } from 'react';
+import React, { ReactElement, useMemo } from 'react';
 import { Button, Card } from 'antd';
 import { shortenAddress, useMeta } from '@oyster/common';
 
@@ -10,6 +10,7 @@ import { ArtType } from '../../types';
 
 interface Props {
   voucherMetadata: string;
+  uri: string;
   name: string;
   authority: string;
   cardsRedeemed?: number;
@@ -20,6 +21,7 @@ interface Props {
 
 const PackCard = ({
   voucherMetadata,
+  uri,
   name,
   authority,
   cardsRedeemed,
@@ -80,7 +82,7 @@ const PackCard = ({
             </div>
           </div>
           <div className="art-content-wrapper">
-            <ArtContent pubkey={voucherMetadata} preview={false} />
+            <ArtContent uri={uri} preview={false} />
           </div>
           <div className="art-name">{name}</div>
         </div>

--- a/js/packages/web/src/views/artworks/components/ItemCard/index.tsx
+++ b/js/packages/web/src/views/artworks/components/ItemCard/index.tsx
@@ -14,7 +14,7 @@ const ItemCard = ({ item }: { item: Item }): ReactElement => {
       pubkey,
       cardsRedeemed,
       edition,
-      info: { authority, allowedAmountToRedeem },
+      info: { authority, allowedAmountToRedeem, uri },
       provingProcessKey,
       voucherMetadataKey,
     } = item;
@@ -31,6 +31,7 @@ const ItemCard = ({ item }: { item: Item }): ReactElement => {
           authority={authority}
           cardsRedeemed={cardsRedeemed}
           allowedAmountToRedeem={allowedAmountToRedeem}
+          uri={uri}
           artView
         />
       </Link>

--- a/js/packages/web/src/views/auctionCreate/AuctionItemCard.tsx
+++ b/js/packages/web/src/views/auctionCreate/AuctionItemCard.tsx
@@ -11,38 +11,53 @@ interface IAuctionItemCard {
   onClose?: () => void;
 }
 
-const AuctionItemCard = ({ current, isSelected, onSelect, onClose }: IAuctionItemCard) => {
+const AuctionItemCard = ({
+  current,
+  isSelected,
+  onSelect,
+  onClose,
+}: IAuctionItemCard) => {
   const { packs, vouchers } = useMeta();
   const shouldShowPacks = process.env.NEXT_ENABLE_NFT_PACKS === 'true';
+
   if (shouldShowPacks) {
     const masterEdition = current.masterEdition?.pubkey;
-    const voucher = Object.values(vouchers).find(v => v?.info?.master === masterEdition);
+    const voucher = Object.values(vouchers).find(
+      v => v?.info?.master === masterEdition,
+    );
+
     if (voucher) {
-      const pack = packs[voucher.info.packSet];
       const {
-        info: {authority, allowedAmountToRedeem, name},
-      } = pack;
+        info: { authority, allowedAmountToRedeem, name, uri },
+      } = packs[voucher.info.packSet];
+
       return (
         // use <div> for correct grid rendering
         <div onClick={onSelect}>
           <PackCard
             name={name}
             voucherMetadata={voucher.info.metadata}
+            uri={uri}
             authority={authority}
             allowedAmountToRedeem={allowedAmountToRedeem}
             onClose={onClose}
             artView
           />
         </div>
-      )
+      );
     }
   }
+
   return (
     <ArtCard
       pubkey={current.metadata.pubkey}
       preview={false}
       onClick={onSelect}
-      className={isSelected ? 'selected-card art-card-for-selector' : 'not-selected-card art-card-for-selector'}
+      className={
+        isSelected
+          ? 'selected-card art-card-for-selector'
+          : 'not-selected-card art-card-for-selector'
+      }
       onClose={onClose}
     />
   );


### PR DESCRIPTION
### Description

This PR improves image loading for packs in My Items. There is a `uri` field that holds a URL to the thumbnail.

### Steps to verify

- Create a pack 
- Go to My Items
- Verify pack has image



