### PR TITLE
refactor(auction-house): remove unnecessary invoke_signed

### DIFF
--- a/rust/auction-house/src/lib.rs
+++ b/rust/auction-house/src/lib.rs
@@ -465,7 +465,7 @@ pub mod auction_house {
 
         if !is_native {
             assert_is_ata(payment_account, &wallet.key(), &treasury_mint.key())?;
-            invoke_signed(
+            invoke(
                 &spl_token::instruction::transfer(
                     token_program.key,
                     &payment_account.key(),
@@ -480,11 +480,10 @@ pub mod auction_house {
                     token_program.to_account_info(),
                     transfer_authority.to_account_info(),
                 ],
-                &[],
             )?;
         } else {
             assert_keys_equal(payment_account.key(), wallet.key())?;
-            invoke_signed(
+            invoke(
                 &system_instruction::transfer(
                     &payment_account.key(),
                     &escrow_payment_account.key(),
@@ -495,7 +494,6 @@ pub mod auction_house {
                     payment_account.to_account_info(),
                     system_program.to_account_info(),
                 ],
-                &[],
             )?;
         }
 
@@ -547,7 +545,7 @@ pub mod auction_house {
             .ok_or(ErrorCode::NumericalOverflow)?;
 
         if token_account.owner == wallet.key() && wallet.is_signer {
-            invoke_signed(
+            invoke(
                 &revoke(
                     &token_program.key(),
                     &token_account.key(),
@@ -560,7 +558,6 @@ pub mod auction_house {
                     token_account.to_account_info(),
                     wallet.to_account_info(),
                 ],
-                &[],
             )?;
         }
 
@@ -924,7 +921,7 @@ pub mod auction_house {
         }
 
         if wallet.is_signer {
-            invoke_signed(
+            invoke(
                 &approve(
                     &token_program.key(),
                     &token_account.key(),
@@ -940,7 +937,6 @@ pub mod auction_house {
                     program_as_signer.to_account_info(),
                     wallet.to_account_info(),
                 ],
-                &[],
             )?;
         }
 
@@ -1046,7 +1042,7 @@ pub mod auction_house {
                 let diff = buyer_price
                     .checked_sub(escrow_payment_account.lamports())
                     .ok_or(ErrorCode::NumericalOverflow)?;
-                invoke_signed(
+                invoke(
                     &system_instruction::transfer(
                         &payment_account.key(),
                         &escrow_payment_account.key(),
@@ -1057,7 +1053,6 @@ pub mod auction_house {
                         escrow_payment_account.to_account_info(),
                         system_program.to_account_info(),
                     ],
-                    &[],
                 )?;
             }
         } else {


### PR DESCRIPTION
I found a few instances of `invoke_signed` calls without any signer seeds. Using `invoke` is clearer in those cases.