### PR TITLE
fix: don't request extra cards on UI for packs

### DIFF
--- a/js/packages/web/src/views/pack/contexts/utils/getProvingProcess.ts
+++ b/js/packages/web/src/views/pack/contexts/utils/getProvingProcess.ts
@@ -54,8 +54,17 @@ export const getProvingProcess = async ({
   const voucherKey = voucher.pubkey;
 
   const voucherTokenAccount = accountByMint.get(editionMint);
+
+  // Calculate already requested but not redeemed cards by summing values in cardsToRedeem
+  const alreadyRequestedCards = provingProcess?.info.cardsToRedeem
+    ? Object.values(
+        Object.fromEntries(provingProcess.info.cardsToRedeem),
+      ).reduce((a, b) => a + b)
+    : 0;
+  const redeemedCards = provingProcess?.info.cardsRedeemed || 0;
+
   const cardsLeftToOpen =
-    pack.info.allowedAmountToRedeem - (provingProcess?.info.cardsRedeemed || 0);
+    pack.info.allowedAmountToRedeem - redeemedCards - alreadyRequestedCards;
 
   if (cardsLeftToOpen === 0 && provingProcess) {
     return provingProcess;


### PR DESCRIPTION
In addition to the contracts PR https://github.com/metaplex/smart-contracts/pull/19
Add a check to not request more than allowed cards to redeem.
