### PR TITLE
Fix for auction primary sales distribution

### DIFF
--- a/js/packages/common/src/contexts/meta/processMetaplexAccounts.ts
+++ b/js/packages/common/src/contexts/meta/processMetaplexAccounts.ts
@@ -16,12 +16,14 @@ import {
   PrizeTrackingTicket,
   decodePrizeTrackingTicket,
   BidRedemptionTicketV2,
-  decodeSafetyDepositConfig,
-  SafetyDepositConfig,
+  decodeSafetyDepositConfigV2,
+  SafetyDepositConfigV2,
   decodeAuctionCache,
   AuctionCache,
   decodeStoreIndexer,
   StoreIndexer,
+  decodeSafetyDepositConfigV1,
+  SafetyDepositConfigV1,
 } from '../../models';
 import { ProcessAccountsFunc } from './types';
 import { METAPLEX_ID, programIds, pubkeyToString } from '../../utils';
@@ -140,9 +142,23 @@ export const processMetaplexAccounts: ProcessAccountsFunc = async (
       }
     }
 
+    if (isSafetyDepositConfigV2Account(account)) {
+      const config = decodeSafetyDepositConfigV2(account.data);
+      const parsedAccount: ParsedAccount<SafetyDepositConfigV2> = {
+        pubkey,
+        account,
+        info: config,
+      };
+      setter(
+        'safetyDepositConfigsByAuctionManagerAndIndex',
+        config.auctionManager + '-' + config.order.toNumber(),
+        parsedAccount,
+      );
+    }
+
     if (isSafetyDepositConfigV1Account(account)) {
-      const config = decodeSafetyDepositConfig(account.data);
-      const parsedAccount: ParsedAccount<SafetyDepositConfig> = {
+      const config = decodeSafetyDepositConfigV1(account.data);
+      const parsedAccount: ParsedAccount<SafetyDepositConfigV1> = {
         pubkey,
         account,
         info: config,
@@ -212,6 +228,9 @@ const isPrizeTrackingTicketV1Account = (account: AccountInfo<Buffer>) =>
 
 const isStoreV1Account = (account: AccountInfo<Buffer>) =>
   account.data[0] === MetaplexKey.StoreV1;
+
+const isSafetyDepositConfigV2Account = (account: AccountInfo<Buffer>) =>
+  account.data[0] === MetaplexKey.SafetyDepositConfigV2;
 
 const isSafetyDepositConfigV1Account = (account: AccountInfo<Buffer>) =>
   account.data[0] === MetaplexKey.SafetyDepositConfigV1;

--- a/js/packages/common/src/contexts/meta/types.ts
+++ b/js/packages/common/src/contexts/meta/types.ts
@@ -20,7 +20,7 @@ import {
   BidRedemptionTicketV2,
   PayoutTicket,
   PrizeTrackingTicket,
-  SafetyDepositConfig,
+  SafetyDepositConfigV2,
   Store,
   StoreIndexer,
   WhitelistedCreator,
@@ -56,7 +56,7 @@ export interface MetaState {
   >;
   safetyDepositConfigsByAuctionManagerAndIndex: Record<
     string,
-    ParsedAccount<SafetyDepositConfig>
+    ParsedAccount<SafetyDepositConfigV2>
   >;
   bidRedemptionV2sByAuctionManagerAndWinningIndex: Record<
     string,

--- a/js/packages/common/src/models/metaplex/deprecatedStates.ts
+++ b/js/packages/common/src/models/metaplex/deprecatedStates.ts
@@ -1,10 +1,14 @@
 import BN from 'bn.js';
 import {
+  AmountRange,
   AuctionManagerStatus,
   BidRedemptionTicket,
   MetaplexKey,
   METAPLEX_PREFIX,
   NonWinningConstraint,
+  ParticipationConfigV2,
+  ParticipationStateV2,
+  SafetyDepositConfigV1,
   WinningConfigType,
   WinningConstraint,
 } from '.';
@@ -333,6 +337,26 @@ export const DEPRECATED_SCHEMA = new Map<any, any>([
     {
       kind: 'struct',
       fields: [['instruction', 'u8']],
+    },
+  ],
+  [
+    SafetyDepositConfigV1,
+    {
+      kind: 'struct',
+      fields: [
+        ['key', 'u8'],
+        ['auctionManager', 'pubkeyAsString'],
+        ['order', 'u64'],
+        ['winningConfigType', 'u8'],
+        ['amountType', 'u8'],
+        ['lengthType', 'u8'],
+        ['amountRanges', [AmountRange]],
+        [
+          'participationConfig',
+          { kind: 'option', type: ParticipationConfigV2 },
+        ],
+        ['participationState', { kind: 'option', type: ParticipationStateV2 }],
+      ],
     },
   ],
 ]);

--- a/js/packages/common/src/models/metaplex/validateSafetyDepositBoxV3.ts
+++ b/js/packages/common/src/models/metaplex/validateSafetyDepositBoxV3.ts
@@ -10,13 +10,13 @@ import {
   getAuctionWinnerTokenTypeTracker,
   getOriginalAuthority,
   getSafetyDepositConfig,
-  SafetyDepositConfig,
+  SafetyDepositConfigV2,
   SCHEMA,
-  ValidateSafetyDepositBoxV2Args,
+  ValidateSafetyDepositBoxV3Args,
 } from '.';
 import { programIds, toPublicKey, StringPublicKey } from '../../utils';
 
-export async function validateSafetyDepositBoxV2(
+export async function validateSafetyDepositBoxV3(
   vault: StringPublicKey,
   metadata: StringPublicKey,
   safetyDepositBox: StringPublicKey,
@@ -29,7 +29,7 @@ export async function validateSafetyDepositBoxV2(
   edition: StringPublicKey,
   whitelistedCreator: StringPublicKey | undefined,
   store: StringPublicKey,
-  safetyDepositConfig: SafetyDepositConfig,
+  safetyDepositConfig: SafetyDepositConfigV2,
 ) {
   const PROGRAM_IDS = programIds();
 
@@ -49,7 +49,7 @@ export async function validateSafetyDepositBoxV2(
     auctionManagerKey,
   );
 
-  const value = new ValidateSafetyDepositBoxV2Args(safetyDepositConfig);
+  const value = new ValidateSafetyDepositBoxV3Args(safetyDepositConfig);
   const data = Buffer.from(serialize(SCHEMA, value));
 
   const keys = [

--- a/js/packages/web/src/actions/addTokensToVault.ts
+++ b/js/packages/web/src/actions/addTokensToVault.ts
@@ -7,7 +7,7 @@ import {
   toPublicKey,
   WalletSigner,
 } from '@oyster/common';
-import { SafetyDepositConfig } from '@oyster/common/dist/lib/models/metaplex/index';
+import { SafetyDepositConfigV2 } from '@oyster/common/dist/lib/models/metaplex/index';
 import { approve } from '@oyster/common/dist/lib/models/account';
 import { createTokenAccount } from '@oyster/common/dist/lib/actions/account';
 import {
@@ -27,7 +27,7 @@ export interface SafetyDepositInstructionTemplate {
     amount: BN;
   };
   draft: SafetyDepositDraft;
-  config: SafetyDepositConfig;
+  config: SafetyDepositConfigV2;
 }
 
 const BATCH_SIZE = 1;

--- a/js/packages/web/src/actions/createAuctionManager.ts
+++ b/js/packages/web/src/actions/createAuctionManager.ts
@@ -38,7 +38,7 @@ import {
   AmountRange,
   ParticipationConfigV2,
   TupleNumericType,
-  SafetyDepositConfig,
+  SafetyDepositConfigV2,
   ParticipationStateV2,
   StoreIndexer,
 } from '@oyster/common/dist/lib/models/metaplex/index';
@@ -56,7 +56,7 @@ import { deprecatedCreateReservationListForTokens } from './deprecatedCreateRese
 import { deprecatedPopulatePrintingTokens } from './deprecatedPopulatePrintingTokens';
 import { setVaultAndAuctionAuthorities } from './setVaultAndAuctionAuthorities';
 import { markItemsThatArentMineAsSold } from './markItemsThatArentMineAsSold';
-import { validateSafetyDepositBoxV2 } from '@oyster/common/dist/lib/models/metaplex/validateSafetyDepositBoxV2';
+import { validateSafetyDepositBoxV3 } from '@oyster/common/dist/lib/models/metaplex/validateSafetyDepositBoxV3';
 import { initAuctionManagerV2 } from '@oyster/common/dist/lib/models/metaplex/initAuctionManagerV2';
 import { cacheAuctionIndexer } from './cacheAuctionInIndexer';
 
@@ -420,7 +420,7 @@ async function buildSafetyDepositArray(
                 ),
               ),
       },
-      config: new SafetyDepositConfig({
+      config: new SafetyDepositConfigV2({
         directArgs: {
           auctionManager: SystemProgram.programId.toBase58(),
           order: new BN(i),
@@ -434,6 +434,7 @@ async function buildSafetyDepositArray(
           winningConfigType: s.winningConfigType,
           participationConfig: null,
           participationState: null,
+          primarySaleHappened: false,
         },
       }),
       draft: s,
@@ -454,7 +455,7 @@ async function buildSafetyDepositArray(
     ]
       .sort()
       .reverse()[0];
-    const config = new SafetyDepositConfig({
+    const config = new SafetyDepositConfigV2({
       directArgs: {
         auctionManager: SystemProgram.programId.toBase58(),
         order: new BN(safetyDeposits.length),
@@ -471,6 +472,7 @@ async function buildSafetyDepositArray(
         participationState: new ParticipationStateV2({
           collectedToAcceptPayment: new BN(0),
         }),
+        primarySaleHappened: false,
       },
     });
 
@@ -737,7 +739,7 @@ async function validateBoxes(
         )
       : undefined;
 
-    await validateSafetyDepositBoxV2(
+    await validateSafetyDepositBoxV3(
       vault,
       safetyDeposits[i].draft.metadata.pubkey,
       safetyDepositBox,

--- a/js/packages/web/src/hooks/useAuctions.ts
+++ b/js/packages/web/src/hooks/useAuctions.ts
@@ -26,7 +26,7 @@ import {
   BidRedemptionTicketV2,
   getBidderKeys,
   MetaplexKey,
-  SafetyDepositConfig,
+  SafetyDepositConfigV2,
   WinningConfigType,
   AuctionViewItem,
 } from '@oyster/common/dist/lib/models/metaplex/index';
@@ -255,7 +255,7 @@ export function processAccountsIntoAuctionView(
   vaults: Record<string, ParsedAccount<Vault>>,
   safetyDepositConfigsByAuctionManagerAndIndex: Record<
     string,
-    ParsedAccount<SafetyDepositConfig>
+    ParsedAccount<SafetyDepositConfigV2>
   >,
   masterEditionsByPrintingMint: Record<string, ParsedAccount<MasterEditionV1>>,
   masterEditionsByOneTimeAuthMint: Record<
@@ -310,7 +310,7 @@ export function processAccountsIntoAuctionView(
     const vault = vaults[auctionManagerInstance.info.vault];
     const auctionManagerKey = auctionManagerInstance.pubkey;
 
-    const safetyDepositConfigs: ParsedAccount<SafetyDepositConfig>[] =
+    const safetyDepositConfigs: ParsedAccount<SafetyDepositConfigV2>[] =
       buildListWhileNonZero(
         safetyDepositConfigsByAuctionManagerAndIndex,
         auctionManagerKey,

--- a/rust/metaplex/program/src/instruction.rs
+++ b/rust/metaplex/program/src/instruction.rs
@@ -86,7 +86,8 @@ pub struct SetStoreIndexArgs {
 }
 
 /// Instructions supported by the Fraction program.
-#[derive(BorshSerialize, BorshDeserialize, Clone)]pub enum MetaplexInstruction {
+#[derive(BorshSerialize, BorshDeserialize, Clone)]
+pub enum MetaplexInstruction {
     /// Initializes an Auction Manager V1
     ///
     ///   0. `[writable]` Uninitialized, unallocated auction manager account with pda of ['metaplex', auction_key from auction referenced below]

--- a/rust/metaplex/program/src/instruction.rs
+++ b/rust/metaplex/program/src/instruction.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         deprecated_state::AuctionManagerSettingsV1,
-        state::{SafetyDepositConfig, TupleNumericType, PREFIX},
+        state::{SafetyDepositConfigV1, TupleNumericType, PREFIX},
     },
     borsh::{BorshDeserialize, BorshSerialize},
     metaplex_token_metadata::state::EDITION_MARKER_BIT_SIZE,
@@ -86,8 +86,7 @@ pub struct SetStoreIndexArgs {
 }
 
 /// Instructions supported by the Fraction program.
-#[derive(BorshSerialize, BorshDeserialize, Clone)]
-pub enum MetaplexInstruction {
+#[derive(BorshSerialize, BorshDeserialize, Clone)]pub enum MetaplexInstruction {
     /// Initializes an Auction Manager V1
     ///
     ///   0. `[writable]` Uninitialized, unallocated auction manager account with pda of ['metaplex', auction_key from auction referenced below]
@@ -584,7 +583,7 @@ pub enum MetaplexInstruction {
     ///   15. `[]` Token metadata program
     ///   16. `[]` System
     ///   17. `[]` Rent sysvar
-    ValidateSafetyDepositBoxV2(SafetyDepositConfig),
+    ValidateSafetyDepositBoxV2(SafetyDepositConfigV1),
 
     /// Note: This requires that auction manager be in a Running state.
     ///
@@ -686,7 +685,35 @@ pub enum MetaplexInstruction {
     ///   8. `[]` System
     ///   8. `[]` Rent sysvar
     SetStoreV2(SetStoreV2Args),
+    /// NOTE: Requires an AuctionManagerV2.
+    ///
+    /// Validates that a given safety deposit box has in it contents that match the given SafetyDepositConfig, and creates said config.
+    /// A stateful call, this will error out if you call it a second time after validation has occurred.
+    ///   0. `[writable]` Uninitialized Safety deposit config, pda of seed ['metaplex', program id, auction manager key, safety deposit key]
+    ///   1. `[writable]` AuctionWinnerTokenTypeTracker, pda of seed ['metaplex', program id, auction manager key, 'totals']
+    ///   2. `[writable]` Auction manager
+    ///   3. `[writable]` Metadata account
+    ///   4. `[writable]` Original authority lookup - unallocated uninitialized pda account with seed ['metaplex', auction key, metadata key]
+    ///                   We will store original authority here to return it later.
+    ///   5. `[]` A whitelisted creator entry for the store of this auction manager pda of ['metaplex', store key, creator key]
+    ///   where creator key comes from creator list of metadata, any will do
+    ///   6. `[]` The auction manager's store key
+    ///   7. `[]` Safety deposit box account
+    ///   8. `[]` Safety deposit box storage account where the actual nft token is stored
+    ///   9. `[]` Mint account of the token in the safety deposit box
+    ///   10. `[]` Edition OR MasterEdition record key
+    ///           Remember this does not need to be an existing account (may not be depending on token), just is a pda with seed
+    ///            of ['metadata', program id, Printing mint id, 'edition']. - remember PDA is relative to token metadata program.
+    ///   11. `[]` Vault account
+    ///   12. `[signer]` Authority
+    ///   13. `[signer optional]` Metadata Authority - Signer only required if doing a full ownership txfer
+    ///   14. `[signer]` Payer
+    ///   15. `[]` Token metadata program
+    ///   16. `[]` System
+    ///   17. `[]` Rent sysvar
+    ValidateSafetyDepositBoxV3(SafetyDepositConfigV2),
 }
+
 
 /// Creates an DeprecatedInitAuctionManager instruction
 #[allow(clippy::too_many_arguments)]
@@ -877,7 +904,7 @@ pub fn create_validate_safety_deposit_box_v2_instruction(
     auction_manager_authority: Pubkey,
     metadata_authority: Pubkey,
     payer: Pubkey,
-    safety_deposit_config: SafetyDepositConfig,
+    safety_deposit_config: SafetyDepositConfigV1,
 ) -> Instruction {
     let (validation, _) = Pubkey::find_program_address(
         &[

--- a/rust/metaplex/program/src/instruction.rs
+++ b/rust/metaplex/program/src/instruction.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         deprecated_state::AuctionManagerSettingsV1,
-        state::{SafetyDepositConfigV1, TupleNumericType, PREFIX},
+        state::{SafetyDepositConfigV1, SafetyDepositConfigV2, TupleNumericType, PREFIX},
     },
     borsh::{BorshDeserialize, BorshSerialize},
     metaplex_token_metadata::state::EDITION_MARKER_BIT_SIZE,

--- a/rust/metaplex/program/src/processor.rs
+++ b/rust/metaplex/program/src/processor.rs
@@ -24,6 +24,7 @@ use {
     solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, msg, pubkey::Pubkey},
     start_auction::process_start_auction,
     validate_safety_deposit_box_v2::process_validate_safety_deposit_box_v2,
+    validate_safety_deposit_box_v3::process_validate_safety_deposit_box_v3,
     withdraw_master_edition::process_withdraw_master_edition,
 };
 
@@ -47,6 +48,7 @@ pub mod set_store_index;
 pub mod set_whitelisted_creator;
 pub mod start_auction;
 pub mod validate_safety_deposit_box_v2;
+pub mod validate_safety_deposit_box_v3;
 pub mod withdraw_master_edition;
 
 pub fn process_instruction<'a>(
@@ -166,6 +168,10 @@ pub fn process_instruction<'a>(
         MetaplexInstruction::SetAuctionCache => {
             msg!("Instruction: Set Auction Cache");
             process_set_auction_cache(program_id, accounts)
+        }
+        MetaplexInstruction::ValidateSafetyDepositBoxV3(safety_deposit_config) => {
+            msg!("Instruction: Validate Safety Deposit Box V3");
+            process_validate_safety_deposit_box_v3(program_id, accounts, safety_deposit_config)
         }
     }
 }

--- a/rust/metaplex/program/src/utils.rs
+++ b/rust/metaplex/program/src/utils.rs
@@ -494,7 +494,8 @@ pub fn assert_safety_deposit_config_valid(
                 ],
             )?;
 
-            if config.data.borrow()[0] != Key::SafetyDepositConfigV1 as u8 {
+            let key = config.data.borrow()[0];
+            if key != Key::SafetyDepositConfigV1 as u8 && key != Key::SafetyDepositConfigV2 as u8 {
                 return Err(MetaplexError::DataTypeMismatch.into());
             }
         }


### PR DESCRIPTION
# Fix for auction primary sales distribution

The problem this solves is that pretty much on a multi-creator auction (let's use 3 as an example) where you have a 34, 33, 33 percent royalty distribution, the auction manager would close using the secondary sales percentage instead of the full 100%, giving the first seller a 93.4% of the funds and the rest a 3.4% or less approx. This occurs because the empty payment action looks at the metadata primary_sale_happened when deciding to do normal or secondary sale distribution. The primary sale flag is flipped when the user claims the item which often happens before funds are settled leading to secondary sale payout instead of primary.

## Steps to reproduce:

- 1. Create a multi creator NFT (34%, 33%, 33%).
- 2. Everyone signs it so you can list.
- 3. List it (Can be a 5m sale or an instant sale).
- 4. Buy with another account.
- 5. Get back to the original account and claim funds.
- 6. It will allocate funds in an unexpected way.

## Changes

Include an additional field on the safety deposit config snapshots the primary sale happened flag at the time of the listing creation. Then in empty payment evaluate the safe deposit config for is_primary_sale instead of the metadata since it was likely switched by the user redeeming the bid.