### PR TITLE
Fix `upload` command error when no cache present

### DIFF
--- a/js/packages/cli/src/commands/upload.ts
+++ b/js/packages/cli/src/commands/upload.ts
@@ -88,6 +88,10 @@ export async function uploadV2({
     cacheContent.program = {};
   }
 
+  if (!cacheContent.items) {
+    cacheContent.items = {};
+  }
+
   const dedupedAssetKeys = getAssetKeysNeedingUpload(cacheContent.items, files);
   const SIZE = dedupedAssetKeys.length;
   console.log('Size', SIZE, dedupedAssetKeys[0]);


### PR DESCRIPTION
Restores the check removed on #1255 that handles no cache file. This is the error currently received when the user uploads for the first time (no cache):

```
upload was not successful, please re-run. TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at getAssetKeysNeedingUpload (/path/to/metaplex/js/packages/cli/src/commands/upload.ts:451:17)
    at uploadV2 (/path/to/metaplex/js/packages/cli/src/commands/upload.ts:91:28)
    at Command.<anonymous> (/path/to/metaplex/js/packages/cli/src/candy-machine-v2-cli.ts:183:21)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
```