### PR TITLE
Display countdown when no FLP ID is specified and CM has not started

### DIFF
--- a/js/packages/fair-launch/src/PhaseHeader.tsx
+++ b/js/packages/fair-launch/src/PhaseHeader.tsx
@@ -46,7 +46,7 @@ export function getPhase(
     curr > candyMachineGoLive
   ) {
     return Phase.Phase4;
-  } else if (fairLaunch?.state.phaseThreeStarted) {
+  } else if (!fairLaunch || fairLaunch?.state.phaseThreeStarted) {
     if (!candyMachine) {
       return Phase.RaffleFinished;
     } else {


### PR DESCRIPTION
There is a bug in the FLP frontend that shows nothing when no `REACT_APP_FAIR_LAUNCH_ID` is specified and it is before the candy machine launch date.

Current behavior:
![bad](https://user-images.githubusercontent.com/94403944/146711247-e24d9f85-01a9-4cd8-9c63-aeceeabd257e.gif)

Behavior after this change:
![good](https://user-images.githubusercontent.com/94403944/146711250-b7c44e1d-3cac-4347-b1b1-5168637798d3.gif)

If anyone has suggestions to fix the jarring display change, please let me know. I didn't want to hold up this fix for that issue, but it would be nice to fix that too!
