### PR TITLE
Add create-metadata command to the JS CLI

### DIFF
--- a/js/packages/cli/src/cli-nft.ts
+++ b/js/packages/cli/src/cli-nft.ts
@@ -1,9 +1,17 @@
-import { program } from 'commander';
-import log from 'loglevel';
-import { mintNFT, updateMetadata } from './commands/mint-nft';
-import { loadWalletKey } from './helpers/accounts';
 import { web3 } from '@project-serum/anchor';
 import { PublicKey } from '@solana/web3.js';
+import { program } from 'commander';
+import * as fs from 'fs';
+import log from 'loglevel';
+import {
+  createMetadata,
+  createMetadataAccount,
+  mintNFT,
+  updateMetadata,
+  validateMetadata,
+} from './commands/mint-nft';
+import { loadWalletKey } from './helpers/accounts';
+import { Data } from './helpers/schema';
 
 program.version('0.0.1');
 log.setLevel('info');
@@ -16,6 +24,47 @@ programCommand('mint')
     const solConnection = new web3.Connection(web3.clusterApiUrl(env));
     const walletKeyPair = loadWalletKey(keypair);
     await mintNFT(solConnection, walletKeyPair, url);
+  });
+
+programCommand('create-metadata')
+  .option('-m, --mint <string>', 'base58 mint key')
+  .option('-u, --url <string>', 'metadata url')
+  .option('-f, --file <string>', 'local file')
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  .action(async (directory, cmd) => {
+    const { keypair, env, mint, url, file } = cmd.opts();
+    const mintKey = new PublicKey(mint);
+    const connection = new web3.Connection(web3.clusterApiUrl(env));
+    const walletKeypair = loadWalletKey(keypair);
+
+    let data: Data;
+
+    if (url) {
+      data = await createMetadata(url);
+      if (!data) {
+        log.error('No metadata found at URL.');
+        return;
+      }
+    } else if (file) {
+      const fileData = JSON.parse(fs.readFileSync(file).toString());
+      log.info('Read from file', fileData);
+      data = validateMetadata({ metadata: fileData, uri: '' });
+    } else {
+      log.error('No metadata source provided.');
+      return;
+    }
+
+    if (!data) {
+      log.error('Metadata not constructed.');
+      return;
+    }
+
+    await createMetadataAccount({
+      connection,
+      data,
+      mintKey,
+      walletKeypair,
+    });
   });
 
 programCommand('update-metadata')


### PR DESCRIPTION
This adds a `create-metadata` command to the JS CLI. I found this useful when I created a fungible token and I wanted to set up Metadata for it :)

Here's what it looks like in use:

```sh
➜  metaplex git:(heads/v1.0.0) ✗ esnode js/packages/cli/src/cli-nft.ts create-metadata -m GvZdo44cPTB8Y8ZfSWqsR5WfqjwHeRtGLJ93KsGoPZjj --keypair ~/.config/solana/id.json -e devnet -f hi.json
wallet public key: Deqr16gDggMTHNqK8QJNdsRqpwiBKzFbEeEPjgyxhdte
Read from file {
  name: 'MAR Coin',
  symbol: 'MAR',
  image: 'https://cdn.lu.ma/community_avatar_0.png',
  seller_fee_basis_points: 0,
  properties: { creators: [ [Object] ] }
}
Metadata created {
  txid: 'vNSqKzDNpRTiksa9aYhLRm2dPKGkPhuZZeNCWtJNCZtN6YcoefYF18coeF2FnVHecaWG7HibtYKXRPxF4yCufma',
  slot: 102343917
}
```