### PR TITLE
fix: remove profile link

### DIFF
--- a/js/packages/common/src/components/Settings/index.tsx
+++ b/js/packages/common/src/components/Settings/index.tsx
@@ -52,15 +52,6 @@ export const Settings = ({
                 &nbsp;{shortenAddress(publicKey?.toBase58())}
               </div>
             </Tooltip>
-
-            <Link
-              to={`/profile/${publicKey?.toBase58()}`}
-              style={{
-                color: 'rgba(255, 255, 255, 0.7)',
-              }}
-            >
-              View profile
-            </Link>
           </>
         )}
         <br />


### PR DESCRIPTION
Issue #1065 
Description: since we don't have yet a route for user profile to avoid confusing has been removed unexisting link