### PR TITLE
remove import of StringPublicKey that does not exist

### DIFF
--- a/js/packages/token-entangler/src/utils/borsh.ts
+++ b/js/packages/token-entangler/src/utils/borsh.ts
@@ -1,7 +1,6 @@
 import { PublicKey } from '@solana/web3.js';
 import { BinaryReader, BinaryWriter } from 'borsh';
 import base58 from 'bs58';
-import { StringPublicKey } from './ids';
 
 export const extendBorsh = () => {
   (BinaryReader.prototype as any).readPubkey = function () {


### PR DESCRIPTION
Build failing from StringPublicKey into borsh.ts and it's not needed. 