### PR TITLE
feat: wallet search on connect

### DIFF
--- a/js/packages/gumdrop/src/components/Claim.tsx
+++ b/js/packages/gumdrop/src/components/Claim.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { RouteComponentProps, } from "react-router-dom";
+import { RouteComponentProps, useHistory} from "react-router-dom";
 import queryString from 'query-string';
 
 import {
@@ -17,7 +17,7 @@ import {
   Stepper,
   TextField,
 } from "@mui/material";
-
+import _find from "lodash/find";
 import {
   useWallet,
 } from "@solana/wallet-adapter-react";
@@ -70,6 +70,7 @@ import {
   chunk,
 } from "../utils/claimant";
 import { coder } from "../utils/merkleDistributor";
+import distributionList from "../dist-list.json";
 
 const walletKeyOrPda = async (
   walletKey : PublicKey,
@@ -624,6 +625,19 @@ export const Claim = (
   const connection = useConnection();
   const wallet = useWallet();
 
+  const history = useHistory();
+
+  React.useEffect(() => {
+    const match: any = _find(distributionList, {
+      handle: wallet?.publicKey?.toBase58(),
+    });
+
+    if (match?.url) {
+      const params = match?.url.split("?")[1];
+      history.push(`/claim?${params}`);
+    }
+  }, [wallet.publicKey]);
+  
   let query = props.location.search;
   if (query && query.length > 0) {
     localStorage.setItem("claimQuery", query);

--- a/js/packages/gumdrop/src/dist-list.json
+++ b/js/packages/gumdrop/src/dist-list.json
@@ -1,0 +1,7 @@
+[
+  {
+    "handle": "yfx28bHkNWsycYZJLfzZX2dZNNfqr2LTf8T1NiHGHxJ",
+    "amount": 9,
+    "url": "https://test.vercel.app/claim?distributor=ABEFHKvf7xB6HNV2gLiFXRqtD2WL2k3wuNvvBA5rQhGM&handle=yfx28bHkNWsycYZJLfzZX2dZNNfqr2LTf8T1NiHGHxJ&amount=9&index=1&proof=Ch847vo3Q1LagEnNpf81MoWL6ytUBBjFAeBRsnDWA7nY,8ZU8JDTF6SpopmM6arCZvs5GKUEhDEfd1e9tgaE1GRzs,6scDSM4PiQCTEgAy7dVNnLD47S3eMqvp4nqspJgubpmv,67L9YpKHu1Vezi5diSqVcd9jEakg3xoPoV4GjEvghPPS,EJ3Ae3UvucSYiSW1TCVRfs6ne3g6A95n34mENTijGZP,5fdtYGNLEE9wPZeLKbzjgz7riRWDnhhUzE8jJsgm9cCx,GCcRHXrJ8Ym36RE1j2QaT1dDevXeP7kdhGkg2j5Hct1a,8Dj9s2q63YezK6wYFxo8uXDCDHqHRSNdovMF4s3DmiCP&pin=NA&config=52sCzaDMomRzUM5ZrEd6qvrtMVWHmARNg8oT6RaRe3gg&uuid=52sCza"
+  }
+]

--- a/js/packages/gumdrop/src/utils/accounts.ts
+++ b/js/packages/gumdrop/src/utils/accounts.ts
@@ -76,11 +76,10 @@ export const fetchCoder = async (
 ): Promise<anchor.Coder | null> => {
   //@ts-ignore
   return new anchor.Coder(
-    await anchor.Program.fetchIdl(
-      //@ts-ignore
-      address,
-      { connection: connection } as anchor.Provider,
-    ),
+    //@ts-ignore
+    await anchor.Program.fetchIdl(address, {
+      connection: connection,
+    } as anchor.Provider),
   );
 };
 

--- a/js/packages/gumdrop/src/utils/accounts.ts
+++ b/js/packages/gumdrop/src/utils/accounts.ts
@@ -5,20 +5,20 @@ import {
   MintInfo,
   MintLayout,
   TOKEN_PROGRAM_ID,
-} from "@solana/spl-token";
+} from '@solana/spl-token';
 import BN from 'bn.js';
 
 import {
   CANDY_MACHINE_ID,
   SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID,
   TOKEN_METADATA_PROGRAM_ID,
-} from "./ids";
+} from './ids';
 
 export const getMintInfo = async (
-  connection : Connection,
-  mint : string
-) : Promise<{ key: PublicKey, info: MintInfo }> => {
-  let mintKey : PublicKey;
+  connection: Connection,
+  mint: string,
+): Promise<{ key: PublicKey; info: MintInfo }> => {
+  let mintKey: PublicKey;
   try {
     mintKey = new PublicKey(mint);
   } catch (err) {
@@ -43,46 +43,52 @@ export const getMintInfo = async (
 };
 
 export const getCreatorTokenAccount = async (
-  walletKey : PublicKey,
-  connection : Connection,
-  mintKey : PublicKey,
-  totalClaim : number,
+  walletKey: PublicKey,
+  connection: Connection,
+  mintKey: PublicKey,
+  totalClaim: number,
 ) => {
-  const [creatorTokenKey, ] = await PublicKey.findProgramAddress(
-    [
-      walletKey.toBuffer(),
-      TOKEN_PROGRAM_ID.toBuffer(),
-      mintKey.toBuffer(),
-    ],
-    SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID
+  const [creatorTokenKey] = await PublicKey.findProgramAddress(
+    [walletKey.toBuffer(), TOKEN_PROGRAM_ID.toBuffer(), mintKey.toBuffer()],
+    SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID,
   );
   const creatorTokenAccount = await connection.getAccountInfo(creatorTokenKey);
   if (creatorTokenAccount === null) {
     throw new Error(`Could not fetch creator token account`);
   }
   if (creatorTokenAccount.data.length !== AccountLayout.span) {
-    throw new Error(`Invalid token account size ${creatorTokenAccount.data.length}`);
+    throw new Error(
+      `Invalid token account size ${creatorTokenAccount.data.length}`,
+    );
   }
-  const creatorTokenInfo = AccountLayout.decode(Buffer.from(creatorTokenAccount.data));
-  if (new BN(creatorTokenInfo.amount, 8, "le").toNumber() < totalClaim) {
+  const creatorTokenInfo = AccountLayout.decode(
+    Buffer.from(creatorTokenAccount.data),
+  );
+  if (new BN(creatorTokenInfo.amount, 8, 'le').toNumber() < totalClaim) {
     throw new Error(`Creator token account does not have enough tokens`);
   }
   return creatorTokenKey;
 };
 
 export const fetchCoder = async (
-  address : anchor.Address,
-  connection : Connection,
-) : Promise<anchor.Coder | null> => {
-  return new anchor.Coder(await anchor.Program.fetchIdl(
-      address, { connection: connection } as anchor.Provider));
-}
+  address: anchor.Address,
+  connection: Connection,
+): Promise<anchor.Coder | null> => {
+  //@ts-ignore
+  return new anchor.Coder(
+    await anchor.Program.fetchIdl(
+      //@ts-ignore
+      address,
+      { connection: connection } as anchor.Provider,
+    ),
+  );
+};
 
 export const getCandyConfig = async (
-  connection : Connection,
-  config : string
-) : Promise<PublicKey> => {
-  let configKey : PublicKey;
+  connection: Connection,
+  config: string,
+): Promise<PublicKey> => {
+  let configKey: PublicKey;
   try {
     configKey = new PublicKey(config);
   } catch (err) {
@@ -103,14 +109,14 @@ export const getCandyMachineAddress = async (
   uuid: string,
 ) => {
   return await PublicKey.findProgramAddress(
-    [Buffer.from("candy_machine"), config.toBuffer(), Buffer.from(uuid)],
+    [Buffer.from('candy_machine'), config.toBuffer(), Buffer.from(uuid)],
     CANDY_MACHINE_ID,
   );
 };
 
 export const getCandyMachine = async (
-  connection : Connection,
-  candyMachineKey : PublicKey,
+  connection: Connection,
+  candyMachineKey: PublicKey,
 ) => {
   const candyMachineCoder = await fetchCoder(CANDY_MACHINE_ID, connection);
   if (candyMachineCoder === null) {
@@ -121,12 +127,12 @@ export const getCandyMachine = async (
     throw new Error(`Could not fetch candy machine`);
   }
   return candyMachineCoder.accounts.decode(
-      "CandyMachine", candyMachineAccount.data);
-}
+    'CandyMachine',
+    candyMachineAccount.data,
+  );
+};
 
-export const getMetadata = async (
-  mint: PublicKey,
-): Promise<PublicKey> => {
+export const getMetadata = async (mint: PublicKey): Promise<PublicKey> => {
   return (
     await PublicKey.findProgramAddress(
       [
@@ -139,9 +145,7 @@ export const getMetadata = async (
   )[0];
 };
 
-export const getEdition = async (
-  mint: PublicKey,
-): Promise<PublicKey> => {
+export const getEdition = async (mint: PublicKey): Promise<PublicKey> => {
   return (
     await PublicKey.findProgramAddress(
       [
@@ -158,7 +162,7 @@ export const getEdition = async (
 export const getEditionMarkerPda = async (
   mint: PublicKey,
   edition: BN,
-) : Promise<PublicKey> => {
+): Promise<PublicKey> => {
   // editions are divided into pages of 31-bytes (248-bits) for more efficient
   // packing to check if an edition is occupied. The offset is determined from
   // the edition passed in through data
@@ -176,4 +180,4 @@ export const getEditionMarkerPda = async (
       TOKEN_METADATA_PROGRAM_ID,
     )
   )[0];
-}
+};


### PR DESCRIPTION
added a sample distribution list for json file of urls, someone would obviously populate their own, and when connecting the wallet will search and populate the url associated with the wallet subsequently populating the form.

tried to prevent formatting, it happened on commit. looks like a linter 