### PR TITLE
use transfer_checked in execute_sale

### DIFF
--- a/rust/auction-house/src/lib.rs
+++ b/rust/auction-house/src/lib.rs
@@ -810,16 +810,19 @@ pub mod auction_house {
         ];
 
         invoke_signed(
-            &spl_token::instruction::transfer(
+            &spl_token::instruction::transfer_checked(
                 token_program.key,
                 &token_account.key(),
+                &token_mint.key(),
                 &buyer_receipt_token_account.key(),
                 &program_as_signer.key(),
                 &[],
                 token_size,
+                0,
             )?,
             &[
                 token_account.to_account_info(),
+                token_mint.to_account_info(),
                 buyer_receipt_clone,
                 program_as_signer.to_account_info(),
                 token_clone,


### PR DESCRIPTION
This makes it so transfer txs will be included when you run `getConfirmedSignaturesForAddress2` on a token mint address. And this means transfer txs will show up on a token mint's Solana Explorer/Solscan pages

Note that Phantom wallet uses this instead of the plain `transfer` instruction