### PR TITLE
Fix packages dependencies

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -2,11 +2,11 @@
   "private": true,
   "workspaces": {
     "packages": [
-      "packages/*"
-    ],
-    "nohoist": [
-      "**/candy-machine-mint/**",
-      "**/token-entangler/**"
+      "packages/cli",
+      "packages/common",
+      "packages/fair-launch",
+      "packages/gumdrop",
+      "packages/web"
     ]
   },
   "keywords": [],
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "bootstrap": "lerna link && lerna bootstrap",
-    "build": "lerna run build",
+    "build": "lerna run build --ignore=token-entangler",
     "build-web": "lerna run build --stream --scope @oyster/common --scope web",
     "start": "cross-env CI=true lerna run start --scope @oyster/common --stream --parallel --scope web",
     "lint": "prettier -c 'packages/*/{src,test}/**/*.ts' && npm run lint:eslint",

--- a/js/package.json
+++ b/js/package.json
@@ -3,6 +3,10 @@
   "workspaces": {
     "packages": [
       "packages/*"
+    ],
+    "nohoist": [
+      "**/candy-machine-mint/**",
+      "**/token-entangler/**"
     ]
   },
   "keywords": [],


### PR DESCRIPTION
Filter token-entangler from build to fix dependencies conflict with fair-launch. This fixes the mint site for Candy Machine v2. 