### PR TITLE
candy-machine-v2-cli: Fix `get_all_mint_addresses` cmd

### DIFF
--- a/js/packages/cli/src/candy-machine-v2-cli.ts
+++ b/js/packages/cli/src/candy-machine-v2-cli.ts
@@ -24,6 +24,7 @@ import {
   loadCandyProgramV2,
   loadWalletKey,
   AccountAndPubkey,
+  deriveCandyMachineV2ProgramAddress,
 } from './helpers/accounts';
 
 import { uploadV2 } from './commands/upload';
@@ -873,8 +874,13 @@ programCommand('get_all_mint_addresses').action(async (directory, cmd) => {
   const walletKeyPair = loadWalletKey(keypair);
   const anchorProgram = await loadCandyProgramV2(walletKeyPair, env);
 
+  const candyMachineId = new PublicKey(cacheContent.program.candyMachine);
+  const [candyMachineAddr] = await deriveCandyMachineV2ProgramAddress(
+    candyMachineId,
+  );
+
   const accountsByCreatorAddress = await getAccountsByCreatorAddress(
-    cacheContent.program.candyMachine,
+    candyMachineAddr.toBase58(),
     anchorProgram.provider.connection,
   );
   const addresses = accountsByCreatorAddress.map(it => {

--- a/js/packages/cli/src/helpers/accounts.ts
+++ b/js/packages/cli/src/helpers/accounts.ts
@@ -260,6 +260,15 @@ export const getCandyMachineAddress = async (
   );
 };
 
+export const deriveCandyMachineV2ProgramAddress = async (
+  candyMachineId: anchor.web3.PublicKey,
+): Promise<[PublicKey, number]> => {
+  return await PublicKey.findProgramAddress(
+    [Buffer.from(CANDY_MACHINE), candyMachineId.toBuffer()],
+    CANDY_MACHINE_PROGRAM_V2_ID,
+  );
+};
+
 export const getConfig = async (
   authority: anchor.web3.PublicKey,
   uuid: string,


### PR DESCRIPTION
Currently, the `get_all_mint_addresses` command returns an empty
list. This has been noted by some users on discord already, but it
doesn't look like an issue has been filed yet.

This PR now properly derives the candy machine v2 address (as in
[metaboss/src/snapshot.rs](https://github.com/samuelvanderwaal/metaboss/blob/edeb9acdb63dc53278c66ffec4d0509b8304c5b7/src/snapshot.rs#L138)).

Usage:
```bash
$ ts-node ./candy-machine-v2-cli.ts get_all_mint_addresses \
    -e devnet -k ~/.config/solana/devnet.json -c cache
wallet public key: 26R5F...
[
  "5hA1Q...",
  "Edy2C..."
]
```