### PR TITLE
fixing sign all v2

### DIFF
--- a/js/packages/cli/src/candy-machine-v2-cli.ts
+++ b/js/packages/cli/src/candy-machine-v2-cli.ts
@@ -772,21 +772,25 @@ programCommand('sign_all')
     const cacheContent = loadCache(cacheName, env);
     const walletKeyPair = loadWalletKey(keypair);
     const anchorProgram = await loadCandyProgramV2(walletKeyPair, env, rpcUrl);
-    const candyAddress = cacheContent.program.candyMachine;
 
     const batchSizeParsed = parseInt(batchSize);
     if (!parseInt(batchSize)) {
       throw new Error('Batch size needs to be an integer!');
     }
 
+    const candyMachineId = new PublicKey(cacheContent.program.candyMachine);
+    const [candyMachineAddr] = await deriveCandyMachineV2ProgramAddress(
+      candyMachineId,
+    );
+
     log.debug('Creator pubkey: ', walletKeyPair.publicKey.toBase58());
     log.debug('Environment: ', env);
-    log.debug('Candy machine address: ', candyAddress);
+    log.debug('Candy machine address: ', cacheContent.program.candyMachine);
     log.debug('Batch Size: ', batchSizeParsed);
     await signAllMetadataFromCandyMachine(
       anchorProgram.provider.connection,
       walletKeyPair,
-      candyAddress,
+      candyMachineAddr.toBase58(),
       batchSizeParsed,
       daemon,
     );


### PR DESCRIPTION
fixing sign_all for v2 by using the derived PDA of the candy machine id closes #1332