### PR TITLE
add missing account for new authority on candymachineV2

### DIFF
--- a/js/packages/cli/src/candy-machine-v2-cli.ts
+++ b/js/packages/cli/src/candy-machine-v2-cli.ts
@@ -688,6 +688,7 @@ programCommand('update_candy_machine')
         accounts: {
           candyMachine,
           authority: walletKeyPair.publicKey,
+          wallet: treasuryWallet,
         },
       });
 


### PR DESCRIPTION
updateAuthority uses the same accounts as updateCandyMachine. Simply added the missing account.