### PR TITLE
Fix fair-launch dependencies problem for `yarn`

### DIFF
--- a/js/packages/common/package.json
+++ b/js/packages/common/package.json
@@ -36,7 +36,7 @@
     "@solana/spl-token": "0.1.6",
     "@solana/spl-token-registry": "0.2.202",
     "@solana/wallet-adapter-base": "^0.4.1",
-    "@solana/wallet-adapter-react": "^0.7.2",
+    "@solana/wallet-adapter-react": "^0.13.1",
     "@solana/wallet-adapter-wallets": "^0.6.2",
     "@solana/web3.js": "^1.21.0",
     "@testing-library/jest-dom": "^4.2.4",

--- a/js/packages/gumdrop/package.json
+++ b/js/packages/gumdrop/package.json
@@ -28,7 +28,7 @@
     "@solana/spl-token": "^0.1.8",
     "@solana/spl-token-registry": "0.2.202",
     "@solana/wallet-adapter-base": "0.4.1",
-    "@solana/wallet-adapter-react": "^0.7.1",
+    "@solana/wallet-adapter-react": "^0.13.1",
     "@solana/wallet-adapter-wallets": "^0.6.1",
     "@solana/web3.js": "^1.24.1",
     "@testing-library/jest-dom": "^5.11.4",

--- a/js/packages/token-entangler/package.json
+++ b/js/packages/token-entangler/package.json
@@ -14,7 +14,7 @@
     "@solana/spl-token": "^0.1.8",
     "@solana/spl-token-registry": "0.2.202",
     "@solana/wallet-adapter-base": "0.4.1",
-    "@solana/wallet-adapter-react": "^0.7.1",
+    "@solana/wallet-adapter-react": "^0.13.1",
     "@solana/wallet-adapter-wallets": "^0.6.1",
     "@solana/web3.js": "^1.24.1",
     "@testing-library/jest-dom": "^5.11.4",

--- a/js/packages/web/package.json
+++ b/js/packages/web/package.json
@@ -15,7 +15,7 @@
     "@solana/spl-token": "0.1.6",
     "@solana/spl-token-registry": "^0.2.202",
     "@solana/wallet-adapter-base": "^0.4.1",
-    "@solana/wallet-adapter-react": "^0.7.2",
+    "@solana/wallet-adapter-react": "^0.13.1",
     "@solana/web3.js": "^1.21.0",
     "@welldone-software/why-did-you-render": "^6.0.5",
     "async-sema": "^3.1.1",

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -5996,11 +5996,6 @@
   resolved "https://registry.yarnpkg.com/@solana/wallet-adapter-react/-/wallet-adapter-react-0.13.1.tgz#7014f85b4d60a1c2b0e8c72c12baa0b1b5172854"
   integrity sha512-Sk45AuOF8EgmR28zcib5NquvOwTpBlyDA8Iku1MVdXUQ9giA/tBwfJw21HIf1r+TVepg+V0xAP5FhP+MX0p6QQ==
 
-"@solana/wallet-adapter-react@^0.7.2":
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/@solana/wallet-adapter-react/-/wallet-adapter-react-0.7.2.tgz#87336260b48422611aee0dea4664d7aeef17c575"
-  integrity sha512-+Ok3ZuFEol2HO3pNVgV7d4To2vXcptLjx32R9vYH1QGMo/ewRxth8sIjvPYo43OsAHLcSfqbKmcjWQ9aXphHnA==
-
 "@solana/wallet-adapter-safepal@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@solana/wallet-adapter-safepal/-/wallet-adapter-safepal-0.3.0.tgz#b1368fd0c5c8864c402cc0f0924f27ee70639e82"
@@ -6018,11 +6013,6 @@
   dependencies:
     "@types/bs58" "^4.0.1"
     bs58 "^4.0.1"
-
-"@solana/wallet-adapter-slope@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@solana/wallet-adapter-slope/-/wallet-adapter-slope-0.1.3.tgz#1ac1bdd90066987f60eac9c7a8b45d49a9eef8a4"
-  integrity sha512-t0q4piJ11KT7XNT+L+dPb/SbQjTH7v8CBbVBwrVtgDht9PRH4+Aq2xHvt1N48dlGpkY60t+8EW2Rw+GgSRf7TA==
 
 "@solana/wallet-adapter-solflare@^0.1.0":
   version "0.1.0"
@@ -6104,7 +6094,7 @@
     "@solana/wallet-adapter-tokenpocket" "^0.2.0"
     "@solana/wallet-adapter-torus" "^0.8.0"
 
-"@solana/wallet-adapter-wallets@^0.6.2":
+"@solana/wallet-adapter-wallets@^0.6.1", "@solana/wallet-adapter-wallets@^0.6.2":
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/@solana/wallet-adapter-wallets/-/wallet-adapter-wallets-0.6.2.tgz#f29d960c41a722b5be50cebd3e34a7ad9709c02c"
   integrity sha512-ndGjI36jDdVnlF5cZUwxPMGcQ+amA9M6uZ4/kcNGzAWtABzbpfKYQ2QpYueJIEwpT6hGrzX/W8B1rEkw1lj6bw==


### PR DESCRIPTION
Since the docs recommends `yarn` to be used as package manager for this project,
In order to fix problem described in #1322 and [this comment](https://github.com/metaplex-foundation/metaplex/issues/1322#issuecomment-1006153851), we need to make sure yarn resolve all `@solana/wallet-adapter-react` to same version.
Unfortunately, yarn doesn't see "^0.7.2" and "^0.13.1" as compatible like npm does, I manually updated them all.

Another way to solve this is to enforce all `@solana/wallet-adapter-react` to be resolved to same version with [resolutions](https://classic.yarnpkg.com/en/docs/selective-version-resolutions/#toc-how-to-use-it) in `package.json` file. But I think it's a workaround and not a long term solution.

# changes
Upgrade all `@solana/wallet-adapter-react` to `^0.13.1`

