### PR TITLE
Update Fair-Launch dev canvas-confetti dependency

### DIFF
--- a/js/packages/fair-launch/package.json
+++ b/js/packages/fair-launch/package.json
@@ -60,6 +60,7 @@
     ]
   },
   "devDependencies": {
+    "@types/canvas-confetti" : "^1.4.2",
     "@types/styled-components": "^5.1.14"
   }
 }


### PR DESCRIPTION
Added a missing dev dependency @types/canvas-confetti, should solve https://github.com/metaplex-foundation/metaplex/issues/1306#issuecomment-1002654316. 

