### PR TITLE
Reverted change on update

### DIFF
--- a/js/packages/common/src/contexts/meta/meta.tsx
+++ b/js/packages/common/src/contexts/meta/meta.tsx
@@ -343,7 +343,6 @@ export function MetaProvider({ children = null as any }) {
     storeAddress,
     isReady,
     page,
-    isLoading,
   ]);
 
   // Fetch metadata on userAccounts change


### PR DESCRIPTION
Reverts change from commit 4c2404d, which is potentially triggering an update of a React component at the wrong time.

![image](https://user-images.githubusercontent.com/729235/148686404-302424b7-419f-4de7-b860-98775d49e73e.png)
