### PR TITLE
Make Manifest Image Replace Function More Forgiving

### DIFF
--- a/js/packages/cli/src/commands/upload.ts
+++ b/js/packages/cli/src/commands/upload.ts
@@ -392,8 +392,7 @@ export async function uploadV2({
                   saveCache(cacheName, env, cacheContent);
                 } catch (e) {
                   log.error(
-                    `saving config line ${ind}-${
-                      keys[indexes[indexes.length - 1]]
+                    `saving config line ${ind}-${keys[indexes[indexes.length - 1]]
                     } failed`,
                     e,
                   );
@@ -490,10 +489,12 @@ function getAssetManifest(dirname: string, assetKey: string): Manifest {
     fs.readFileSync(manifestPath).toString(),
   );
   manifest.image = manifest.image.replace('image', assetIndex);
-  manifest.properties.files[0].uri = manifest.properties.files[0].uri.replace(
-    'image',
-    assetIndex,
-  );
+  if (manifest.properties?.files?.length > 0) {
+    manifest.properties.files[0].uri = manifest.properties.files[0]?.uri?.replace(
+      'image',
+      assetIndex,
+    );
+  }
   return manifest;
 }
 
@@ -556,8 +557,7 @@ async function writeIndices({
                 saveCache(cacheName, env, cache);
               } catch (err) {
                 log.error(
-                  `Saving config line ${ind}-${
-                    keys[indexes[indexes.length - 1]]
+                  `Saving config line ${ind}-${keys[indexes[indexes.length - 1]]
                   } failed`,
                   err,
                 );


### PR DESCRIPTION
Makes the manifest function not fail badly when a metadata JSON file is missing the properties: files attribute, which is technically unnecessary and not required for marketplaces or storefronts to display the metadata. Fixes #1464 