### PR TITLE
Make bundlr upload (arweave-sol) retry instead of ungraceful fail

### DIFF
--- a/js/packages/cli/src/commands/upload.ts
+++ b/js/packages/cli/src/commands/upload.ts
@@ -231,14 +231,6 @@ export async function uploadV2({
                 allIndexesInSlice[i] >= lastPrinted + tick ||
                 allIndexesInSlice[i] === 0
               ) {
-                lastPrinted = i;
-                log.info(`Processing asset: ${allIndexesInSlice[i]}`);
-              }
-
-              if (
-                allIndexesInSlice[i] >= lastPrinted + tick ||
-                allIndexesInSlice[i] === 0
-              ) {
                 lastPrinted = allIndexesInSlice[i];
                 log.info(`Processing asset: ${allIndexesInSlice[i]}`);
               }
@@ -340,7 +332,8 @@ export async function uploadV2({
                   saveCache(cacheName, env, cacheContent);
                 } catch (e) {
                   log.error(
-                    `saving config line ${ind}-${keys[indexes[indexes.length - 1]]
+                    `saving config line ${ind}-${
+                      keys[indexes[indexes.length - 1]]
                     } failed`,
                     e,
                   );
@@ -441,10 +434,8 @@ function getAssetManifest(dirname: string, assetKey: string): Manifest {
   );
   manifest.image = manifest.image.replace('image', assetIndex);
   if (manifest.properties?.files?.length > 0) {
-    manifest.properties.files[0].uri = manifest.properties.files[0]?.uri?.replace(
-      'image',
-      assetIndex,
-    );
+    manifest.properties.files[0].uri =
+      manifest.properties.files[0]?.uri?.replace('image', assetIndex);
   }
   return manifest;
 }
@@ -508,7 +499,8 @@ async function writeIndices({
                 saveCache(cacheName, env, cache);
               } catch (err) {
                 log.error(
-                  `Saving config line ${ind}-${keys[indexes[indexes.length - 1]]
+                  `Saving config line ${ind}-${
+                    keys[indexes[indexes.length - 1]]
                   } failed`,
                   err,
                 );

--- a/js/packages/cli/src/helpers/upload/arweave-bundle.ts
+++ b/js/packages/cli/src/helpers/upload/arweave-bundle.ts
@@ -9,6 +9,7 @@ import { StorageType } from '../storage-type';
 import { Keypair } from '@solana/web3.js';
 import { getType, getExtension } from 'mime';
 import { AssetKey } from '../../types';
+import { sleep } from '../various';
 import Transaction from 'arweave/node/lib/transaction';
 import Bundlr from '@bundlr-network/client';
 
@@ -511,8 +512,27 @@ export function* makeArweaveBundleUploadGenerator(
         log.info(`${cost.toNumber() / LAMPORTS} SOL to upload`);
         await bundlr.fund(cost.toNumber());
         for (const tx of bundlrTransactions) {
-          await tx.upload();
+          let attempts = 0;
+
+          const uploadTransaction = async () => {
+            await tx.upload().catch(async (err: Error) => {
+              attempts++;
+              if (attempts >= 3) {
+                throw err;
+              }
+
+              log.warn(
+                `Failed bundlr upload, automatically retrying transaction in 10s (attempt: ${attempts})`,
+                err,
+              );
+              await sleep(10 * 1000);
+              await uploadTransaction();
+            });
+          };
+
+          await uploadTransaction();
         }
+
         log.info('Bundle uploaded!');
       }
 


### PR DESCRIPTION
At the moment if for any reasons arweave-sol upload fails including the network problems/timeouts and the actual fund function call succeeds people will lose their money, this PR just adds simple retry mechanism to the bundlr upload to reduce the chance of losing funds due to occasional instability issues.

The tx upload will be attempted 3 times with small sleep of 10s between each attempt if none of the 3 times succeed it will ungraceful fail (fall back to old behavior)

Ideally we should be looking in to adding arweave fund tx id to the cache and reuse it on new reuploads if possible to completely or in most cases reduce the chance of losing funds (something to think about for later)