### PR TITLE
fixed the keypair requirement for offline commands

### DIFF
--- a/js/packages/cli/src/candy-machine-v2-cli.ts
+++ b/js/packages/cli/src/candy-machine-v2-cli.ts
@@ -976,7 +976,7 @@ function programCommand(name: string) {
       'Solana cluster env name',
       'devnet', //mainnet-beta, testnet, devnet
     )
-    .requiredOption('-k, --keypair <path>', `Solana wallet location`)
+    .option('-k, --keypair <path>', 'Solana wallet location','--keypair not provided')
     .option('-l, --log-level <string>', 'log level', setLogLevel)
     .option('-c, --cache-name <string>', 'Cache file name', 'temp');
 }


### PR DESCRIPTION
keypair has been required for all commands including offline ones like "create_generative_art". It has been introduced in PR #1409