### PR TITLE
fixed `update_existing_nfts_from_latest_cache_file` in cm v2

### DIFF
--- a/js/packages/cli/src/commands/updateFromCache.ts
+++ b/js/packages/cli/src/commands/updateFromCache.ts
@@ -62,6 +62,15 @@ export async function updateMetadataFromCache(
   cacheContent: any,
   newCacheContent: any,
 ) {
+  const utf8Encode = new TextEncoder();
+  const temp = await PublicKey.findProgramAddress(
+    [
+      utf8Encode.encode('candy_machine'),
+      new PublicKey(candyMachineAddress).toBytes(),
+    ],
+    new PublicKey('cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ'),
+  );
+  candyMachineAddress = temp[0].toString();
   const metadataByCandyMachine = await getAccountsByCreatorAddress(
     candyMachineAddress,
     connection,

--- a/js/packages/cli/src/commands/updateFromCache.ts
+++ b/js/packages/cli/src/commands/updateFromCache.ts
@@ -17,6 +17,7 @@ import {
   METADATA_SCHEMA,
   UpdateMetadataArgs,
 } from '../helpers/schema';
+import { deriveCandyMachineV2ProgramAddress } from '../helpers/accounts';
 
 const SIGNING_INTERVAL = 60 * 1000; //60s
 
@@ -62,15 +63,10 @@ export async function updateMetadataFromCache(
   cacheContent: any,
   newCacheContent: any,
 ) {
-  const utf8Encode = new TextEncoder();
-  const temp = await PublicKey.findProgramAddress(
-    [
-      utf8Encode.encode('candy_machine'),
-      new PublicKey(candyMachineAddress).toBytes(),
-    ],
-    new PublicKey('cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ'),
+  const [candyMachineAddr] = await deriveCandyMachineV2ProgramAddress(
+    new PublicKey(candyMachineAddress),
   );
-  candyMachineAddress = temp[0].toString();
+  candyMachineAddress = candyMachineAddr.toBase58();
   const metadataByCandyMachine = await getAccountsByCreatorAddress(
     candyMachineAddress,
     connection,


### PR DESCRIPTION
the `update_existing_nfts_from_latest_cache_file` command in v2 has not been wokring because it assumed the first creator of the mint is the cm account. Based on that the metadata lookup has been performed. I've changed it to the address derived from `candy_machine` and cm address seed.