### PR TITLE
Fix serious verify command bug on rerun with partially verified cache

### DIFF
--- a/js/packages/cli/src/commands/upload.ts
+++ b/js/packages/cli/src/commands/upload.ts
@@ -343,6 +343,7 @@ export async function uploadV2({
                     cacheContent.items[keys[i]] = {
                       ...cacheContent.items[keys[i]],
                       onChain: true,
+                      verifyRun: false,
                     };
                   });
                   saveCache(cacheName, env, cacheContent);
@@ -453,6 +454,7 @@ function getAssetManifest(dirname: string, assetKey: string): Manifest {
     manifest.properties.files[0].uri =
       manifest.properties.files[0]?.uri?.replace('image', assetIndex);
   }
+
   return manifest;
 }
 


### PR DESCRIPTION
At the moment verify command is broken... it only works if all the assets verified at the same time. If you only were able to verify first set of assets in your cache and not the second one when you try to rerun verify command it will fail as the index will be pointing from 0 for your second set and the addresses and names it is pointing will not math the reality.

This might bring alot of confusions as after you run verify command and get some parts of your collection unverified and then trying uploading again and run second time verify it will fail and reset your just uploaded indices back to onChain false

This PR corrects the verify command to actually look through affected keys instead of indexes of the entries in the array. Have also added small improvement to reset verifyRun to false if we write indices for that specific entry.

also enable logging to better express the command execution