### PR TITLE
fix: fixing multiple bugs on test script

### DIFF
--- a/js/packages/cli/src/candy-machine-v1-cli.ts
+++ b/js/packages/cli/src/candy-machine-v1-cli.ts
@@ -299,7 +299,7 @@ programCommand('withdraw')
               cpf,
             );
             log.info(
-              `${cg.pubkey} has been withdrawn. \nTransaction Signarure: ${tx}`,
+              `${cg.pubkey} has been withdrawn. \nTransaction Signature: ${tx}`,
             );
           }
         } catch (e) {

--- a/js/packages/cli/src/candy-machine-v2-cli.ts
+++ b/js/packages/cli/src/candy-machine-v2-cli.ts
@@ -364,7 +364,6 @@ programCommand('verify_upload')
 
     console.log('Key size', keys.length);
     await Promise.all(
-<<<<<<< HEAD
       chunks(keys, 500).map(async allIndexesInSlice => {
         for (let i = 0; i < allIndexesInSlice.length; i++) {
           // Save frequently.
@@ -384,29 +383,6 @@ programCommand('verify_upload')
           if (!name.match(cacheItem.name) || !uri.match(cacheItem.link)) {
             //leaving here for debugging reasons, but it's pretty useless. if the first upload fails - all others are wrong
             /*log.info(
-=======
-      chunks(Array.from(Array(keys.length).keys()), 500).map(
-        async allIndexesInSlice => {
-          for (let i = 0; i < allIndexesInSlice.length; i++) {
-            // Save frequently.
-            if (i % 100 == 0) saveCache(cacheName, env, cacheContent);
-
-            const key = keys[allIndexesInSlice[i]];
-            log.debug('Looking at key ', allIndexesInSlice[i]);
-
-            const thisSlice = candyMachine.data.slice(
-              CONFIG_ARRAY_START_V2 + 4 + CONFIG_LINE_SIZE_V2 * Number(key),
-              CONFIG_ARRAY_START_V2 +
-                4 +
-                CONFIG_LINE_SIZE_V2 * (Number(key) + 1),
-            );
-            const name = fromUTF8Array([...thisSlice.slice(2, 34)]);
-            const uri = fromUTF8Array([...thisSlice.slice(40, 240)]);
-            const cacheItem = cacheContent.items[key];
-            if (!name.match(cacheItem.name) || !uri.match(cacheItem.link)) {
-              //leaving here for debugging reasons, but it's pretty useless. if the first upload fails - all others are wrong
-              /*log.info(
->>>>>>> 69126d04 (fix: fixing multiple bugs on test script)
                 `Name (${name}) or uri (${uri}) didnt match cache values of (${cacheItem.name})` +
                   `and (${cacheItem.link}). marking to rerun for image`,
                 key,

--- a/js/packages/cli/src/candy-machine-v2-cli.ts
+++ b/js/packages/cli/src/candy-machine-v2-cli.ts
@@ -364,6 +364,7 @@ programCommand('verify_upload')
 
     console.log('Key size', keys.length);
     await Promise.all(
+<<<<<<< HEAD
       chunks(keys, 500).map(async allIndexesInSlice => {
         for (let i = 0; i < allIndexesInSlice.length; i++) {
           // Save frequently.
@@ -383,6 +384,29 @@ programCommand('verify_upload')
           if (!name.match(cacheItem.name) || !uri.match(cacheItem.link)) {
             //leaving here for debugging reasons, but it's pretty useless. if the first upload fails - all others are wrong
             /*log.info(
+=======
+      chunks(Array.from(Array(keys.length).keys()), 500).map(
+        async allIndexesInSlice => {
+          for (let i = 0; i < allIndexesInSlice.length; i++) {
+            // Save frequently.
+            if (i % 100 == 0) saveCache(cacheName, env, cacheContent);
+
+            const key = keys[allIndexesInSlice[i]];
+            log.debug('Looking at key ', allIndexesInSlice[i]);
+
+            const thisSlice = candyMachine.data.slice(
+              CONFIG_ARRAY_START_V2 + 4 + CONFIG_LINE_SIZE_V2 * Number(key),
+              CONFIG_ARRAY_START_V2 +
+                4 +
+                CONFIG_LINE_SIZE_V2 * (Number(key) + 1),
+            );
+            const name = fromUTF8Array([...thisSlice.slice(2, 34)]);
+            const uri = fromUTF8Array([...thisSlice.slice(40, 240)]);
+            const cacheItem = cacheContent.items[key];
+            if (!name.match(cacheItem.name) || !uri.match(cacheItem.link)) {
+              //leaving here for debugging reasons, but it's pretty useless. if the first upload fails - all others are wrong
+              /*log.info(
+>>>>>>> 69126d04 (fix: fixing multiple bugs on test script)
                 `Name (${name}) or uri (${uri}) didnt match cache values of (${cacheItem.name})` +
                   `and (${cacheItem.link}). marking to rerun for image`,
                 key,

--- a/js/packages/cli/src/candy-machine-v2-cli.ts
+++ b/js/packages/cli/src/candy-machine-v2-cli.ts
@@ -289,7 +289,7 @@ programCommand('withdraw')
               cpf,
             );
             log.info(
-              `${cg.pubkey} has been withdrawn. \nTransaction Signarure: ${tx}`,
+              `${cg.pubkey} has been withdrawn. \nTransaction Signature: ${tx}`,
             );
           }
         } catch (e) {
@@ -373,12 +373,10 @@ programCommand('verify_upload')
             log.debug('Looking at key ', allIndexesInSlice[i]);
 
             const thisSlice = candyMachine.data.slice(
+              CONFIG_ARRAY_START_V2 + 4 + CONFIG_LINE_SIZE_V2 * Number(key),
               CONFIG_ARRAY_START_V2 +
                 4 +
-                CONFIG_LINE_SIZE_V2 * allIndexesInSlice[i],
-              CONFIG_ARRAY_START_V2 +
-                4 +
-                CONFIG_LINE_SIZE_V2 * (allIndexesInSlice[i] + 1),
+                CONFIG_LINE_SIZE_V2 * (Number(key) + 1),
             );
             const name = fromUTF8Array([...thisSlice.slice(2, 34)]);
             const uri = fromUTF8Array([...thisSlice.slice(40, 240)]);

--- a/js/packages/cli/src/commands/upload.ts
+++ b/js/packages/cli/src/commands/upload.ts
@@ -243,14 +243,6 @@ export async function uploadV2({
                 log.info(`Processing asset: ${allIndexesInSlice[i]}`);
               }
 
-              if (
-                allIndexesInSlice[i] >= lastPrinted + tick ||
-                allIndexesInSlice[i] === 0
-              ) {
-                lastPrinted = allIndexesInSlice[i];
-                log.info(`Processing asset: ${allIndexesInSlice[i]}`);
-              }
-
               let link, imageLink;
               try {
                 switch (storage) {

--- a/js/packages/cli/test/run-test-v2.sh
+++ b/js/packages/cli/test/run-test-v2.sh
@@ -435,6 +435,7 @@ if [ "${CHANGE}" = "Y" ]; then
     upload
     verify_upload
     check_changed
+    verify_upload
     mag "<<<"
 else
     blu "Skipping 3 (Editing cache and testing reupload)"

--- a/js/packages/cli/test/run-test-v2.sh
+++ b/js/packages/cli/test/run-test-v2.sh
@@ -435,7 +435,6 @@ if [ "${CHANGE}" = "Y" ]; then
     upload
     verify_upload
     check_changed
-    verify_upload
     mag "<<<"
 else
     blu "Skipping 3 (Editing cache and testing reupload)"

--- a/js/packages/cli/test/run-test-v2.sh
+++ b/js/packages/cli/test/run-test-v2.sh
@@ -359,9 +359,9 @@ function clean_up {
 
 # edit cache file for reupload
 function change_cache {
-    cat $CACHE_FILE | jq -c ".items.\"0\".onChain=false|.items.\"0\".name=\"Changed 0\"|del(.items.\""$LAST_INDEX"\")" \
+    cat $CACHE_FILE | jq -c ".items.\"0\".onChain=false|.items.\"0\".name=\"Changed #0\"|del(.items.\""$LAST_INDEX"\")" \
         >$CACHE_FILE.tmp && mv $CACHE_FILE.tmp $CACHE_FILE
-    if [[ $(cat $CACHE_FILE | grep "Changed 0") ]]; then
+    if [[ $(cat $CACHE_FILE | grep "Changed #0") ]]; then
         grn "Success: cache file changed"
     else 
         red "Failure: cache file was not changed"
@@ -377,7 +377,7 @@ function check_changed {
     temp_file=$(mktemp)
     echo $CANDY | xargs -I{} solana account {} -u $RPC -o $temp_file
 
-    if [[ $(strings $temp_file | grep -a "Changed 0") ]]; then
+    if [[ $(strings $temp_file | grep -a "Changed #0") ]]; then
         grn "Success: item 0 found on chain"
     else
         red "Failure: new item 0 not found on chain"
@@ -435,6 +435,7 @@ if [ "${CHANGE}" = "Y" ]; then
     upload
     verify_upload
     check_changed
+    verify_upload
     mag "<<<"
 else
     blu "Skipping 3 (Editing cache and testing reupload)"


### PR DESCRIPTION
fixing: 

- Reupload test is failing occasionally
- rm ${temp_file} (line 486) fails if function check_changed is never called
- "Processing asset 0" is printed twice.
- Spelling error in withdraw command "Transaction Signarure"

closes #1544