### PR TITLE
Allow CM creation from custom cache file with custom links and skipping upload process

### DIFF
--- a/js/packages/cli/src/commands/upload.ts
+++ b/js/packages/cli/src/commands/upload.ts
@@ -100,13 +100,7 @@ export async function uploadV2({
     : undefined;
 
   if (!cacheContent.program.uuid) {
-    const firstAssetKey = dedupedAssetKeys[0];
-    const firstAssetManifest = getAssetManifest(
-      dirname,
-      firstAssetKey.index.includes('json')
-        ? firstAssetKey.index
-        : `${firstAssetKey.index}.json`,
-    );
+    const firstAssetManifest = getAssetManifest(dirname, '0.json');
 
     try {
       const remainingAccounts = [];


### PR DESCRIPTION
This PR will allow creation of the CM from the cache file which can point to any website which is hosting their own metadata. Basic steps is to create custom cache with links and onChain: false in it which point to off chain metadata.


The steps will be CM will take 0.json file from assets to pull some metadata for onchain metadata for CM then the upload will be skipped as all the links already have been added to the cache file. The next step script will be doing is writing indices to the candy machine and done you have CM ready !

Custom cache should have program set to empty object before the first upload.
