### PR TITLE
Candy Machine UI: isActive doesn't consider endSettings correctly

### DIFF
--- a/js/packages/candy-machine-ui/src/candy-machine.ts
+++ b/js/packages/candy-machine-ui/src/candy-machine.ts
@@ -185,10 +185,10 @@ export const getCandyMachineState = async (
       isActive:
         (presale ||
           state.data.goLiveDate.toNumber() < new Date().getTime() / 1000) &&
-        (state.endSettings
-          ? state.endSettings.endSettingType.date
-            ? state.endSettings.number.toNumber() > new Date().getTime() / 1000
-            : itemsRedeemed < state.endSettings.number.toNumber()
+        (state.data.endSettings
+          ? state.data.endSettings.endSettingType.date
+            ? state.data.endSettings.number.toNumber() > new Date().getTime() / 1000
+            : itemsRedeemed < state.data.endSettings.number.toNumber()
           : true),
       isPresale: presale,
       goLiveDate: state.data.goLiveDate,


### PR DESCRIPTION
`endSettings` is found under the `data` struct (as can easily be seen on line 198).

One way to see this manifest in bugs:
- set up a whitelist with `presale: false` and give the candy machine a start and end date.
- when the end date is reached, the UI never changes over to the COMPLETED state.