### PR TITLE
Candy Machine UI: update UI to COMPLETED when end date reached

### DIFF
--- a/js/packages/candy-machine-ui/src/Home.tsx
+++ b/js/packages/candy-machine-ui/src/Home.tsx
@@ -161,6 +161,25 @@ const Home = (props: HomeProps) => {
     refreshCandyMachineState,
   ]);
 
+  // if an end date is set, setup a timer to refresh the candy machine state
+  // after it ends (w/a small delay), to catch that the mint is no longer active
+  useEffect(() => {
+    if (candyMachine && candyMachine.state.endSettings) {
+      const endSettings = candyMachine.state.endSettings;
+      if (endSettings.endSettingType.date) {
+        const endDate = endSettings.number.toNumber();
+        const currentDate = new Date().getTime() / 1000;
+        if (currentDate < endDate) {
+          const millisUntilEndDate = (endDate - currentDate) * 1000;
+          const delay5SecMillis = 5000;
+          setTimeout(() => {
+            refreshCandyMachineState();
+          }, millisUntilEndDate + delay5SecMillis);
+        }
+      }
+    }
+  }, [candyMachine, refreshCandyMachineState]);
+
   return (
     <Container style={{ marginTop: 100 }}>
       <Container maxWidth="xs" style={{ position: 'relative' }}>

--- a/js/packages/candy-machine-ui/src/candy-machine.ts
+++ b/js/packages/candy-machine-ui/src/candy-machine.ts
@@ -35,7 +35,10 @@ interface CandyMachineState {
     expireOnUse: boolean;
     gatekeeperNetwork: anchor.web3.PublicKey;
   };
-  endSettings: null | [number, anchor.BN];
+  endSettings: null | {
+    endSettingType: any;
+    number: anchor.BN;
+  };
   whitelistMintSettings: null | {
     mode: any;
     mint: anchor.web3.PublicKey;


### PR DESCRIPTION
Follow on to #1571 - when we hit the end date set for a candy machine, the UI doesn't take any action.

This PR sets a timer to refresh the candy machine if the browser window is still open when the end date is reached. This will cause the isActive state to be updated and the UI to show the COMPLETED state.

Note that this is a best effort attempt. The frontend UI and the blockchain clocks _could_ be out of sync to some degree, so for that reason I introduced a 5s delay before attempting the update.