### PR TITLE
fix: video not showing in the homepage cards

### DIFF
--- a/js/packages/web/src/components/ArtContent/index.tsx
+++ b/js/packages/web/src/components/ArtContent/index.tsx
@@ -130,29 +130,30 @@ const VideoArtContent = ({
         />
       </div>
     ) : (
-      <video
-        className={className}
-        playsInline={true}
-        autoPlay={true}
-        muted={true}
-        controls={true}
-        controlsList="nodownload"
-        style={style}
-        loop={true}
-        poster={uri}
-      >
-        {likelyVideo && (
-          <source src={likelyVideo} type="video/mp4" style={style} />
-        )}
-        {animationURL && (
-          <source src={animationURL} type="video/mp4" style={style} />
-        )}
-        {files
-          ?.filter(f => typeof f !== 'string')
-          .map((f: any) => (
-            <source src={f.uri} type={f.type} style={style} />
-          ))}
-      </video>
+      <div className={`${className} square`}>
+        <video
+          playsInline={true}
+          autoPlay={true}
+          muted={true}
+          controls={true}
+          controlsList="nodownload"
+          style={style}
+          loop={true}
+          poster={uri}
+        >
+          {likelyVideo && (
+            <source src={likelyVideo} type="video/mp4" style={style} />
+          )}
+          {animationURL && (
+            <source src={animationURL} type="video/mp4" style={style} />
+          )}
+          {files
+            ?.filter(f => typeof f !== 'string')
+            .map((f: any) => (
+              <source src={f.uri} type={f.type} style={style} />
+            ))}
+        </video>
+      </div>
     );
 
   return content;

--- a/js/packages/web/src/components/AuctionRenderCard/index.less
+++ b/js/packages/web/src/components/AuctionRenderCard/index.less
@@ -13,6 +13,10 @@
   padding-bottom: 100%;
   overflow: hidden;
   border-radius: 12px;
+  & > video {
+    max-width: 100%;
+    height: auto;
+  }
   @media (max-width: 1100px) {
     margin-left: 0;
   }


### PR DESCRIPTION
# Problem
If the primary NFT is a video, they won't show in the homepage cards

# Solution
This is a css Issue so it was solved by displaying the video container correctly. This was tested by creating an auction/sale with a video NFT and make sure the video is played in the homepage auction card

Before:
![image](https://user-images.githubusercontent.com/25460766/150592963-108d84b4-03b1-4925-8508-173e4cb0ace7.png)

After: 
![video](https://user-images.githubusercontent.com/25460766/150593112-d1e6c948-09ef-45bd-937e-8f643faaa97a.gif)
