### PR TITLE
feat: add max supply and verify creators options to nft cli

### DIFF
--- a/js/packages/cli/src/cli-nft.ts
+++ b/js/packages/cli/src/cli-nft.ts
@@ -14,13 +14,24 @@ programCommand('mint')
   .option('-u, --url <string>', 'metadata url')
   .option(
     '-c, --collection <string>',
-    'Optional: Set this NFT as a part of a collection, Note you must be updat authority for this to work.',
+    'Optional: Set this NFT as a part of a collection, Note you must be the update authority for this to work.',
   )
   .option('-um, --use-method <string>', 'Optional: Single, Multiple, or Burn')
   .option('-tum, --total-uses <number>', 'Optional: Allowed Number of Uses')
+  .option('-ms, --max-supply <number>', 'Optional: Max Supply')
+  .option('-vc, --verify-creators <number>', 'Optional: 0 or 1')
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   .action(async (directory, cmd) => {
-    const { keypair, env, url, collection, useMethod, totalUses } = cmd.opts();
+    const {
+      keypair,
+      env,
+      url,
+      collection,
+      useMethod,
+      totalUses,
+      maxSupply,
+      verifyCreators,
+    } = cmd.opts();
     const solConnection = new web3.Connection(getCluster(env));
     let structuredUseMethod;
     try {
@@ -33,12 +44,16 @@ programCommand('mint')
     if (collection !== undefined) {
       collectionKey = new PublicKey(collection);
     }
+    const supply = maxSupply || 0;
+    const verify = typeof verifyCreators === 'undefined' ? 1 : verifyCreators;
     await mintNFT(
       solConnection,
       walletKeyPair,
       url,
       true,
       collectionKey,
+      supply,
+      verify,
       structuredUseMethod,
     );
   });
@@ -52,10 +67,19 @@ programCommand('update-metadata')
   )
   .option('-um, --use-method <string>', 'Optional: Single, Multiple, or Burn')
   .option('-tum, --total-uses <number>', 'Optional: Allowed Number of Uses')
+  .option('-vc, --verify-creators <number>', 'Optional: 0 or 1')
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   .action(async (directory, cmd) => {
-    const { keypair, env, mint, url, collection, useMethod, totalUses } =
-      cmd.opts();
+    const {
+      keypair,
+      env,
+      mint,
+      url,
+      collection,
+      useMethod,
+      totalUses,
+      verifyCreators,
+    } = cmd.opts();
     const mintKey = new PublicKey(mint);
     const solConnection = new web3.Connection(getCluster(env));
     const walletKeyPair = loadWalletKey(keypair);
@@ -79,12 +103,15 @@ programCommand('update-metadata')
     if (collection) {
       collectionKey = new PublicKey(collection);
     }
+
+    const verify = typeof verifyCreators === 'undefined' ? 1 : verifyCreators;
     await updateMetadata(
       mintKey,
       solConnection,
       walletKeyPair,
       url,
       collectionKey,
+      verify,
       structuredUseMethod,
     );
   });

--- a/js/packages/cli/src/cli-nft.ts
+++ b/js/packages/cli/src/cli-nft.ts
@@ -19,7 +19,10 @@ programCommand('mint')
   .option('-um, --use-method <string>', 'Optional: Single, Multiple, or Burn')
   .option('-tum, --total-uses <number>', 'Optional: Allowed Number of Uses')
   .option('-ms, --max-supply <number>', 'Optional: Max Supply')
-  .option('-vc, --verify-creators <number>', 'Optional: 0 or 1')
+  .option(
+    '-nvc, --no-verify-creators',
+    'Optional: Disable Verification of Creators',
+  )
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   .action(async (directory, cmd) => {
     const {
@@ -45,7 +48,7 @@ programCommand('mint')
       collectionKey = new PublicKey(collection);
     }
     const supply = maxSupply || 0;
-    const verify = typeof verifyCreators === 'undefined' ? 1 : verifyCreators;
+
     await mintNFT(
       solConnection,
       walletKeyPair,
@@ -53,7 +56,7 @@ programCommand('mint')
       true,
       collectionKey,
       supply,
-      verify,
+      verifyCreators,
       structuredUseMethod,
     );
   });
@@ -67,7 +70,10 @@ programCommand('update-metadata')
   )
   .option('-um, --use-method <string>', 'Optional: Single, Multiple, or Burn')
   .option('-tum, --total-uses <number>', 'Optional: Allowed Number of Uses')
-  .option('-vc, --verify-creators <number>', 'Optional: 0 or 1')
+  .option(
+    '-nvc, --no-verify-creators',
+    'Optional: Disable Verification of Creators',
+  )
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   .action(async (directory, cmd) => {
     const {
@@ -104,14 +110,13 @@ programCommand('update-metadata')
       collectionKey = new PublicKey(collection);
     }
 
-    const verify = typeof verifyCreators === 'undefined' ? 1 : verifyCreators;
     await updateMetadata(
       mintKey,
       solConnection,
       walletKeyPair,
       url,
       collectionKey,
-      verify,
+      verifyCreators,
       structuredUseMethod,
     );
   });

--- a/js/packages/cli/src/commands/mint-nft.ts
+++ b/js/packages/cli/src/commands/mint-nft.ts
@@ -37,7 +37,7 @@ import {
 export const createMetadata = async (
   metadataLink: string,
   collection: PublicKey,
-  verifyCreators: 0 | 1,
+  verifyCreators: boolean,
   uses?: Uses,
 ): Promise<DataV2> => {
   // Metadata
@@ -76,7 +76,7 @@ export const createMetadata = async (
       new Creator({
         address: creator.address,
         share: creator.share,
-        verified: verifyCreators,
+        verified: verifyCreators ? 1 : 0,
       }),
   );
   return new DataV2({
@@ -99,7 +99,7 @@ export const mintNFT = async (
   mutableMetadata: boolean = true,
   collection: PublicKey = null,
   maxSupply: number = 0,
-  verifyCreators: 0 | 1,
+  verifyCreators: boolean,
   use: Uses = null,
 ): Promise<PublicKey | void> => {
   // Retrieve metadata
@@ -243,7 +243,7 @@ export const updateMetadata = async (
   walletKeypair: Keypair,
   metadataLink: string,
   collection: PublicKey = null,
-  verifyCreators: 0 | 1,
+  verifyCreators: boolean,
   uses: Uses,
 ): Promise<PublicKey | void> => {
   // Retrieve metadata

--- a/js/packages/cli/src/commands/mint-nft.ts
+++ b/js/packages/cli/src/commands/mint-nft.ts
@@ -37,6 +37,7 @@ import {
 export const createMetadata = async (
   metadataLink: string,
   collection: PublicKey,
+  verifyCreators: 0 | 1,
   uses?: Uses,
 ): Promise<DataV2> => {
   // Metadata
@@ -75,7 +76,7 @@ export const createMetadata = async (
       new Creator({
         address: creator.address,
         share: creator.share,
-        verified: 1,
+        verified: verifyCreators,
       }),
   );
   return new DataV2({
@@ -97,10 +98,17 @@ export const mintNFT = async (
   metadataLink: string,
   mutableMetadata: boolean = true,
   collection: PublicKey = null,
+  maxSupply: number = 0,
+  verifyCreators: 0 | 1,
   use: Uses = null,
 ): Promise<PublicKey | void> => {
   // Retrieve metadata
-  const data = await createMetadata(metadataLink, collection, use);
+  const data = await createMetadata(
+    metadataLink,
+    collection,
+    verifyCreators,
+    use,
+  );
   if (!data) return;
 
   // Create wallet from keypair
@@ -193,7 +201,7 @@ export const mintNFT = async (
         ...METADATA_SCHEMA,
         ...CreateMasterEditionV3Args.SCHEMA,
       ]),
-      new CreateMasterEditionV3Args({ maxSupply: new anchor.BN(0) }),
+      new CreateMasterEditionV3Args({ maxSupply: new anchor.BN(maxSupply) }),
     ),
   );
 
@@ -235,10 +243,16 @@ export const updateMetadata = async (
   walletKeypair: Keypair,
   metadataLink: string,
   collection: PublicKey = null,
+  verifyCreators: 0 | 1,
   uses: Uses,
 ): Promise<PublicKey | void> => {
   // Retrieve metadata
-  const data = await createMetadata(metadataLink, collection, uses);
+  const data = await createMetadata(
+    metadataLink,
+    collection,
+    verifyCreators,
+    uses,
+  );
   if (!data) return;
 
   const metadataAccount = await getMetadata(mintKey);


### PR DESCRIPTION
# Pull Request - Metaplex

## Scope

- Add max supply and verify creators options to js/packages/cli/src/cli-nft.ts mint command
- Add verify creators option to js/packages/cli/src/cli-nft.ts update-metadata command

## Work Done

- Add max supply and verify creators options to js/packages/cli/src/cli-nft.ts mint command
- Add verify creators option to js/packages/cli/src/cli-nft.ts update-metadata command

## Steps to Test

- from js/packages/cli/src run (assuming that you have your keypair defined and metadata set up):

```
ts-node cli-nft.ts mint --env devnet --keypair <PATH-TO-KEYPAIR-JSON>  --url <URL-TO-METADATA> --max-supply 5 --verify-creators 0
```

and for update metadata:

```
ts-node cli-nft.ts update-metadata --env devnet --keypair <PATH-TO-KEYPAIR-JSON>  --mint <BASE-58-MINT-KEY> --url <URL-TO-METADATA> --verify-creators 0
```
