### PR TITLE
check if goLiveDate is not `null`

### DIFF
--- a/js/packages/candy-machine-ui/src/candy-machine.ts
+++ b/js/packages/candy-machine-ui/src/candy-machine.ts
@@ -184,7 +184,7 @@ export const getCandyMachineState = async (
       isSoldOut: itemsRemaining === 0,
       isActive:
         (presale ||
-          state.data.goLiveDate.toNumber() < new Date().getTime() / 1000) &&
+          state.data.goLiveDate?.toNumber() < new Date().getTime() / 1000) &&
         (state.data.endSettings
           ? state.data.endSettings.endSettingType.date
             ? state.data.endSettings.number.toNumber() > new Date().getTime() / 1000


### PR DESCRIPTION
getCandyMachineState failed when `goLiveDate ` was not set.
Now it will set `isActive` to `false`