### PR TITLE
show creator from thumbnail in homepage cards on load

### DIFF
--- a/js/packages/web/src/hooks/useCreators.ts
+++ b/js/packages/web/src/hooks/useCreators.ts
@@ -12,7 +12,7 @@ export const useCreators = (auction?: AuctionView) => {
         ...(
           [
             ...(auction?.items || []).flat().map(item => item?.metadata),
-            auction?.participationItem?.metadata,
+            auction?.thumbnail?.metadata,
           ]
             .filter(item => item && item.info)
             .map(item => item?.info.data.creators || [])


### PR DESCRIPTION
![Screen Shot 2022-01-21 at 9 33 33 AM](https://user-images.githubusercontent.com/14321810/150545090-1b9a2269-f1cd-476d-9a26-d0ad7386ca4e.png)

# Problem
Since the auction data is loaded when you visit the auction detail page, the creator information is not loading until that point.

# Solution

The thumbnail of the auction has its metadata available at first load so we now use that to load creator information.
This was tested by simply loading the homepage and confirm that the creator information is displayed immediately in the auction cards