### PR TITLE
fix(bidding): Revoke before canceling for placing bid

### DIFF
--- a/js/packages/web/src/actions/cancelBid.ts
+++ b/js/packages/web/src/actions/cancelBid.ts
@@ -150,6 +150,9 @@ export async function setupCancelBid(
       cancelInstructions,
     );
     signers.push(cancelSigners);
-    instructions.push([...cancelInstructions, ...cleanupInstructions]);
+    instructions.push([
+      ...cancelInstructions,
+      ...cleanupInstructions.reverse(),
+    ]);
   }
 }

--- a/js/packages/web/src/actions/sendPlaceBid.ts
+++ b/js/packages/web/src/actions/sendPlaceBid.ts
@@ -160,7 +160,7 @@ export async function setupPlaceBid(
     instructions,
   );
 
-  overallInstructions.push([...instructions, ...cleanupInstructions]);
+  overallInstructions.push([...instructions, ...cleanupInstructions.reverse()]);
   overallSigners.push(signers);
   return bid;
 }

--- a/js/packages/web/src/actions/sendRedeemBid.ts
+++ b/js/packages/web/src/actions/sendRedeemBid.ts
@@ -822,7 +822,7 @@ export async function setupRedeemParticipationInstructions(
         : null,
       myInstructions,
     );
-    instructions.push([...myInstructions, ...cleanupInstructions]);
+    instructions.push([...myInstructions, ...cleanupInstructions.reverse()]);
     signers.push(mySigners);
     const metadata = await getMetadata(mint);
 
@@ -1008,7 +1008,10 @@ async function deprecatedSetupRedeemParticipationInstructions(
         receivingSolAccountOrAta,
       );
       newTokenBalance = 1;
-      instructions.push([...winningPrizeInstructions, ...cleanupInstructions]);
+      instructions.push([
+        ...winningPrizeInstructions,
+        ...cleanupInstructions.reverse(),
+      ]);
     }
   }
 


### PR DESCRIPTION
# Problem
Due to a change in the core `spl_token` program. The order of clean-up instructions matters. This fix was rolled out and tested on the same codebase on holaplex.

# Solution 
Reverse the clean up instructions so the delegate is removed before the close account