### PR TITLE
Update README, remove broken bin and 'pkg'

### DIFF
--- a/js/packages/cli/README.md
+++ b/js/packages/cli/README.md
@@ -2,6 +2,10 @@
 
 https://user-images.githubusercontent.com/81876372/133098938-dc2c91a6-1280-4ee1-bf0e-db0ccc972ff7.mp4
 
+## Documentation
+
+Gettting started and usage instructions can be found at https://docs.metaplex.com/candy-machine-v2/introduction
+
 ## Settings examples
 
 ```json
@@ -340,80 +344,18 @@ Also with PSDs, make sure your default visible layer is at the bottom of the fol
 }
 ```
 
-Install and build
+## Development
+
+### Build
 
 ```
 yarn install
 yarn build
-yarn run package:linuxb
-OR
-yarn run package:linux
-OR
-yarn run package:macos-x64
-OR
-yarn run package:macos-m1
 ```
 
-You can now either use `metaplex` OR the `ts-node cli` to execute the following commands.
-
-1. Upload your images and metadata. Refer to the NFT [standard](https://docs.metaplex.com/nft-standard) for the correct format.
+### Lint and test
 
 ```
-metaplex upload ~/nft-test/mini_drop --keypair ~/.config/solana/id.json
-ts-node cli upload ~/nft-test/mini_drop --keypair ~/.config/solana/id.json
-```
-
-2. Verify everything is uploaded. Rerun the first command until it is.
-
-```
-metaplex verify --keypair ~/.config/solana/id.json
-ts-node cli verify --keypair ~/.config/solana/id.json
-```
-
-3. Create your candy machine. It can cost up to ~15 solana per 10,000 images.
-
-```
-metaplex create_candy_machine -k ~/.config/solana/id.json -p 1
-ts-node cli create_candy_machine -k ~/.config/solana/id.json -p 3
-```
-
-4. Set the start date and update the price of your candy machine.
-
-```
-metaplex update_candy_machine -k ~/.config/solana/id.json -d "20 Apr 2021 04:20:00 GMT" -p 0.1
-ts-node cli update_candy_machine -k ~/.config/solana/id.json -d "20 Apr 2021 04:20:00 GMT" -p 0.1
-```
-
-5. Test mint a token (provided it's after the start date)
-
-```
-metaplex mint_one_token -k ~/.config/solana/id.json
-ts-node cli mint_one_token -k ~/.config/solana/id.json
-```
-
-6. Test mint multiple tokens
-
-```
-metaplex mint_multiple_tokens -k ~/.config/solana/id.json -n 100
-ts-node cli mint_multiple_tokens -k ~/.config/solana/id.json -n 100
-```
-
-6. Check if you received any tokens.
-
-```
-spl-token accounts
-```
-
-7. If you are listed as a creator, run this command to sign your NFTs post sale. This will sign only the latest candy machine that you've created (stored in .cache/candyMachineList.json).
-
-```
-metaplex sign_candy_machine_metadata -k ~/.config/solana/id.json
-ts-node cli sign_candy_machine_metadata -k ~/.config/solana/id.json
-```
-
-8. If you wish to sign metadata from another candy machine run with the --cndy flag.
-
-```
-metaplex sign_candy_machine_metadata -k ~/.config/solana/id.json --cndy CANDY_MACHINE_ADDRESS_HERE
-ts-node cli sign_candy_machine_metadata -k ~/.config/solana/id.json --cndy CANDY_MACHINE_ADDRESS_HERE
+yarn test
+yarn test
 ```

--- a/js/packages/cli/package.json
+++ b/js/packages/cli/package.json
@@ -3,17 +3,9 @@
   "version": "0.0.2",
   "main": "./build/cli.js",
   "license": "MIT",
-  "bin": {
-    "metaplex": "./build/candy-machine-cli.js"
-  },
   "scripts": {
     "build": "tsc -p ./src",
     "watch": "tsc -w -p ./src",
-    "package:linux": "pkg . --no-bytecode --targets node14-linux-x64 --output bin/linux/metaplex",
-    "package:linuxb": "pkg . --targets node14-linux-x64 --output bin/linux/metaplex",
-    "package:win": "pkg . --targets node14-win-x64 --output bin/win/metaplex",
-    "package:macos-x64": "pkg . --targets node14-macos-x64 --output bin/macos/metaplex",
-    "package:macos-m1": "pkg . --targets node14-macos-arm64 --output bin/macos/metaplex",
     "format": "prettier --loglevel warn --write \"**/*.{ts,js,json,yaml}\"",
     "format:check": "prettier --loglevel warn --check \"**/*.{ts,js,json,yaml}\"",
     "lint": "eslint \"src/**/*.ts\" --fix",
@@ -74,7 +66,6 @@
     "@types/offscreencanvas": "^2019.6.4",
     "@types/webgl2": "^0.0.6",
     "jest": "^27.4.5",
-    "pkg": "^5.3.1",
     "typescript": "^4.3.5"
   }
 }


### PR DESCRIPTION
README is currently out of date with instructions from when Candy
Machine V1 was the only option. Point users to the official docs,
remove 'pkg' for now since it's broken currently.

- Remove 'pkg' from development deps
- Remove 'bin' setting in package.json
- Update README to point to official docs
- Replace outdated docs at the bottom of the page with basic
  build, lint, test instructions

See: https://github.com/metaplex-foundation/metaplex/issues/1419