### PR TITLE
Respect chosen cluster when fetching tokens

### DIFF
--- a/js/packages/web/src/components/AuctionCard/index.tsx
+++ b/js/packages/web/src/components/AuctionCard/index.tsx
@@ -242,7 +242,7 @@ export const AuctionCard = ({
 
   const mintKey = auctionView.auction.info.tokenMint;
   const balance = useUserBalance(mintKey);
-  const tokenInfo = useTokenList().mainnetTokens.filter(
+  const tokenInfo = useTokenList().subscribedTokens.filter(
     m => m.address == mintKey,
   )[0];
   const symbol = tokenInfo

--- a/js/packages/web/src/components/AuctionNumbers/index.tsx
+++ b/js/packages/web/src/components/AuctionNumbers/index.tsx
@@ -53,7 +53,7 @@ export const AuctionNumbers = (props: {
   const isUpcoming = auctionView.state === AuctionViewState.Upcoming;
   const isStarted = auctionView.state === AuctionViewState.Live;
 
-  const tokenInfo = useTokenList().mainnetTokens.filter(m=>m.address == auctionView.auction.info.tokenMint)[0]
+  const tokenInfo = useTokenList().subscribedTokens.filter(m=>m.address == auctionView.auction.info.tokenMint)[0]
   const ended = isEnded(state);
 
   return (

--- a/js/packages/web/src/components/AuctionRenderCard/index.tsx
+++ b/js/packages/web/src/components/AuctionRenderCard/index.tsx
@@ -20,7 +20,7 @@ export const AuctionRenderCard = (props: AuctionCard) => {
   const creators = useCreators(auctionView);
   const name = art?.title || ' ';
 
-  const tokenInfo = useTokenList().mainnetTokens.filter(m=>m.address == auctionView.auction.info.tokenMint)[0]
+  const tokenInfo = useTokenList().subscribedTokens.filter(m=>m.address == auctionView.auction.info.tokenMint)[0]
   const { status, amount } = useAuctionStatus(auctionView);
 
   const card = (

--- a/js/packages/web/src/components/FundsIssueModal/index.tsx
+++ b/js/packages/web/src/components/FundsIssueModal/index.tsx
@@ -12,7 +12,7 @@ export const FundsIssueModal = (props: {
   onClose: () => void
 }) => {
   const {currentFunds: balance, minimumFunds, message} = props
-  const tokenInfo = useTokenList().mainnetTokens.filter(m=>m.address == WRAPPED_SOL_MINT.toBase58())[0]
+  const tokenInfo = useTokenList().subscribedTokens.filter(m=>m.address == WRAPPED_SOL_MINT.toBase58())[0]
   return (
       <MetaplexModal
         title={"Transaction Alert"}

--- a/js/packages/web/src/components/TokenDialog/index.tsx
+++ b/js/packages/web/src/components/TokenDialog/index.tsx
@@ -24,7 +24,7 @@ export function TokenButton({
   mint: PublicKey;
   onClick: () => void;
 }) {
-  const tokenMap = useTokenList().mainnetTokens;
+  const tokenMap = useTokenList().subscribedTokens;
   let tokenInfo = tokenMap.filter(t => t.address == mint.toBase58())[0];
 
   return (

--- a/js/packages/web/src/contexts/coingecko.tsx
+++ b/js/packages/web/src/contexts/coingecko.tsx
@@ -36,7 +36,7 @@ const CoingeckoContext =
 export function CoingeckoProvider({ children = null as any }) {
   const [solPrice, setSolPrice] = useState<number>(0);
   const [allSplPrices, setAllSplPrices] = useState<AllSplTokens[]>([]);
-  const tokenList = useTokenList().mainnetTokens
+  const tokenList = useTokenList().subscribedTokens
 
   useEffect(() => {
     let timerId = 0;

--- a/js/packages/web/src/contexts/tokenList.tsx
+++ b/js/packages/web/src/contexts/tokenList.tsx
@@ -13,7 +13,7 @@ export const SPL_REGISTRY_SOLLET_TAG = "wrapped-sollet";
 export const SPL_REGISTRY_WORM_TAG = "wormhole";
 
 export interface TokenListContextState {
-  mainnetTokens: TokenInfo[];
+  subscribedTokens: TokenInfo[];
   tokenMap: Map<string, TokenInfo>;
   wormholeMap: Map<string, TokenInfo>;
   solletMap: Map<string, TokenInfo>;
@@ -43,12 +43,12 @@ export function SPLTokenListProvider({ children = null as any }) {
   const hasOtherTokens = !!process.env.NEXT_SPL_TOKEN_MINTS;
 
   // Added tokenList to know in which currency the auction is (SOL or other SPL)
-  const mainnetTokens = tokenList?tokenList.filterByClusterSlug("mainnet-beta").getList().filter(f=> subscribedTokenMints.some(s=> s == f.address) )
+  const subscribedTokens = tokenList?tokenList.filterByClusterSlug("mainnet-beta").getList().filter(f=> subscribedTokenMints.some(s=> s == f.address) )
     :[]
 
   const tokenMap = useMemo(() => {
     const tokenMap = new Map();
-    mainnetTokens.forEach((t: TokenInfo) => {
+    subscribedTokens.forEach((t: TokenInfo) => {
       tokenMap.set(t.address, t);
     });
     return tokenMap;
@@ -56,7 +56,7 @@ export function SPLTokenListProvider({ children = null as any }) {
 
   // Tokens with USD(x) quoted markets.
   const swappableTokens = useMemo(() => {
-    const tokens = mainnetTokens.filter((t: TokenInfo) => {
+    const tokens = subscribedTokens.filter((t: TokenInfo) => {
       const isUsdxQuoted =
         t.extensions?.serumV3Usdt || t.extensions?.serumV3Usdc;
       return isUsdxQuoted;
@@ -69,7 +69,7 @@ export function SPLTokenListProvider({ children = null as any }) {
 
   // Sollet wrapped tokens.
   const [swappableTokensSollet, solletMap] = useMemo(() => {
-    const tokens = mainnetTokens.filter((t: TokenInfo) => {
+    const tokens = subscribedTokens.filter((t: TokenInfo) => {
       const isSollet = t.tags?.includes(SPL_REGISTRY_SOLLET_TAG);
       return isSollet;
     });
@@ -84,7 +84,7 @@ export function SPLTokenListProvider({ children = null as any }) {
 
   // Wormhole wrapped tokens.
   const [swappableTokensWormhole, wormholeMap] = useMemo(() => {
-    const tokens = mainnetTokens.filter((t: TokenInfo) => {
+    const tokens = subscribedTokens.filter((t: TokenInfo) => {
       const isSollet = t.tags?.includes(SPL_REGISTRY_WORM_TAG);
       return isSollet;
     });
@@ -99,7 +99,7 @@ export function SPLTokenListProvider({ children = null as any }) {
 
   return (
     <TokenListContext.Provider value={{
-      mainnetTokens,
+      subscribedTokens,
       tokenMap,
       wormholeMap,
       solletMap,
@@ -124,9 +124,9 @@ export const useSwappableTokens = () => {
 }
 
 export const queryTokenList = () => {
-  const { mainnetTokens } = useTokenList();
+  const { subscribedTokens } = useTokenList();
 
-  return mainnetTokens;
+  return subscribedTokens;
 };
 
 export const useTokenList = () => {

--- a/js/packages/web/src/contexts/tokenList.tsx
+++ b/js/packages/web/src/contexts/tokenList.tsx
@@ -2,9 +2,9 @@ import React, { useContext, useEffect, useMemo, useState } from 'react';
 import {
   TokenInfo,
   TokenListContainer,
-  TokenListProvider,
 } from "@solana/spl-token-registry";
 import { WRAPPED_SOL_MINT } from '@project-serum/serum/lib/token-instructions';
+import { useConnectionConfig } from '@oyster/common';
 
 // Tag in the spl-token-registry for sollet wrapped tokens.
 export const SPL_REGISTRY_SOLLET_TAG = "wrapped-sollet";
@@ -36,14 +36,16 @@ export function SPLTokenListProvider({ children = null as any }) {
       ...process.env.NEXT_SPL_TOKEN_MINTS.split(",")
     ]: [WRAPPED_SOL_MINT]
 
+  const { tokens } = useConnectionConfig();
+
   useEffect(() => {
-    new TokenListProvider().resolve().then(setTokenList);
-  }, [setTokenList]);
+    setTokenList(new TokenListContainer(Array.from(tokens.values())))
+  }, [setTokenList, tokens]);
 
   const hasOtherTokens = !!process.env.NEXT_SPL_TOKEN_MINTS;
 
   // Added tokenList to know in which currency the auction is (SOL or other SPL)
-  const subscribedTokens = tokenList?tokenList.filterByClusterSlug("mainnet-beta").getList().filter(f=> subscribedTokenMints.some(s=> s == f.address) )
+  const subscribedTokens = tokenList?tokenList.getList().filter(f=> subscribedTokenMints.some(s=> s == f.address) )
     :[]
 
   const tokenMap = useMemo(() => {

--- a/js/packages/web/src/views/auction/index.tsx
+++ b/js/packages/web/src/views/auction/index.tsx
@@ -110,7 +110,7 @@ export const AuctionView = () => {
   const description = data?.description;
   const attributes = data?.attributes;
 
-  const tokenInfo = useTokenList()?.mainnetTokens.filter(
+  const tokenInfo = useTokenList()?.subscribedTokens.filter(
     m => m.address == auction?.auction.info.tokenMint,
   )[0];
 
@@ -435,7 +435,7 @@ const BidLine = (props: {
   const { publicKey } = useWallet();
   const bidder = bid.info.bidderPubkey;
   const isme = publicKey?.toBase58() === bidder;
-  const tokenInfo = useTokenList().mainnetTokens.filter(
+  const tokenInfo = useTokenList().subscribedTokens.filter(
     m => m.address == mintKey,
   )[0];
 


### PR DESCRIPTION
I'm not sure why the list of SPL Tokens was hardcoded to be fetched from `mainnet-beta`, instead of respecting the same endpoint being used in the global connection and chosen from the UI/LocalStorage/param. I asked about this in the #storefront Discord channel but didn't get a response.

With this PR, the list of SPL Tokens is filtered by whatever cluster is chosen by the user and not always `mainnet-beta`.

If there's a reason this was hardcoded maybe it's a good idea to add a comment in the code about it. But I saw no reason for it.

Most of the changes are just a rename of variables from `mainnetTokens` to `subscribedTokens` to make it less cluster-specific and more semantic.

The real change is to reuse the already filtered by chain id list of tokens coming from the connection instead of using a hardcoded filter by cluster name.