### PR TITLE
fixed the type of `endSettings`

### DIFF
--- a/js/packages/candy-machine-ui/src/candy-machine.ts
+++ b/js/packages/candy-machine-ui/src/candy-machine.ts
@@ -35,7 +35,10 @@ interface CandyMachineState {
     expireOnUse: boolean;
     gatekeeperNetwork: anchor.web3.PublicKey;
   };
-  endSettings: null | [number, anchor.BN];
+  endSettings: null | {
+    number: anchor.BN;
+    endSettingType: any
+  };
   whitelistMintSettings: null | {
     mode: any;
     mint: anchor.web3.PublicKey;


### PR DESCRIPTION
The type of `endSettings` has been wrong, making it impossible to use the `endSettings` outside the `candy-machine.ts`.

It was :
``endSettings: null || [number, anchor.BN]``

Corrected to : 

``  endSettings: null | {
    number: anchor.BN;
    endSettingType: any
  };``
  
  Console output:
![image](https://user-images.githubusercontent.com/6533433/151339860-dfcdee69-60a7-456d-b282-6f3f4dfd850b.png)
