### PR TITLE
fixing selector nft modal

### DIFF
--- a/js/packages/web/src/components/Modals/index.less
+++ b/js/packages/web/src/components/Modals/index.less
@@ -1,7 +1,9 @@
 .ant-modal:not(.big-modal){
   width: 500px !important;
 }
-
+.big-modal > .ant-modal-content > .ant-modal-body > {
+  width: inherit !important;
+}
 .ant-modal-body {
   border-radius: 12px;
   width: 500px;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/34045043/151414835-8835569e-89f5-4338-a796-ee3f89a169e1.png)

# Problem
The nft selection modal has style issues

# Solution
fix the width of big modals