### PR TITLE
Print candy machine state to console on update

### DIFF
--- a/js/packages/candy-machine-ui/src/Home.tsx
+++ b/js/packages/candy-machine-ui/src/Home.tsx
@@ -82,6 +82,7 @@ const Home = (props: HomeProps) => {
           props.candyMachineId,
           props.connection,
         );
+        console.log(JSON.stringify(cndy.state, null, 4));
         setCandyMachine(cndy);
       } catch (e) {
         console.log('There was a problem fetching Candy Machine state');


### PR DESCRIPTION
While testing out a candy machine deployment, it is helpful to see the data being fetched.

This pull request simply logs out the candy machine state every time it is refreshed.

This feature actually used to be in the old version of the website - and due to how rarely people deviate from the boilerplate site, 95% of the time real mint sites included that info - quite helpful when they do not include an items minted count!