### PR TITLE
Bump civic/solana-gateway-react to version 0.4.12

### DIFF
--- a/js/packages/candy-machine-ui/package.json
+++ b/js/packages/candy-machine-ui/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.0",
   "private": true,
   "dependencies": {
-    "@civic/solana-gateway-react": "^0.4.11",
+    "@civic/solana-gateway-react": "^0.4.12",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.60",


### PR DESCRIPTION
This fixes an issue where the GatewayProvider would re-render unnecessarily when a parent component props are updated.