### PR TITLE
Eliminate type confusion by using actual return type of getTokenListContainerPromise

### DIFF
--- a/js/packages/web/src/contexts/tokenList.tsx
+++ b/js/packages/web/src/contexts/tokenList.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect, useMemo, useState } from 'react';
 import { getTokenListContainerPromise } from '@oyster/common';
-import { TokenInfo, TokenListContainer } from "@solana/spl-token-registry";
+import { TokenInfo } from "@solana/spl-token-registry";
 import { WRAPPED_SOL_MINT } from '@project-serum/serum/lib/token-instructions';
 
 // Tag in the spl-token-registry for sollet wrapped tokens.
@@ -24,7 +24,9 @@ const TokenListContext =
   React.createContext<TokenListContextState | null>(null);
 
 export function SPLTokenListProvider({ children = null as any }) {
-  const [tokenList, setTokenList] = useState<TokenListContainer | null>(null);
+  const [tokenList, setTokenList] = useState<Awaited<
+    ReturnType<typeof getTokenListContainerPromise>
+  > | null>(null);
 
   const subscribedTokenMints = process.env.NEXT_SPL_TOKEN_MINTS?
     [
@@ -34,7 +36,7 @@ export function SPLTokenListProvider({ children = null as any }) {
     ]: [WRAPPED_SOL_MINT]
 
   useEffect(() => {
-    getTokenListContainerPromise().then(()=>setTokenList);
+    getTokenListContainerPromise().then(setTokenList);
   }, [setTokenList]);
 
   const hasOtherTokens = !!process.env.NEXT_SPL_TOKEN_MINTS;


### PR DESCRIPTION
So this is annoying. In `js/packages/web/src/contexts/tokenList.tsx` there are _two_ paths to import the `TokenListContainer` type:

1. metaplex/js/node_modules/@solana/spl-token-registry/dist/main/lib/tokenlist
2. metaplex/js/packages/web/node_modules/@solana/spl-token-registry/dist/main/lib/tokenlist

Even though these are legit the same type, because they are from different sources, Typescript doesn't trust their private members.

```
Failed to compile.

./src/contexts/tokenList.tsx:37:41
Type error: Argument of type 'Dispatch<SetStateAction<TokenListContainer | null>>' is not assignable to parameter of type '(value: TokenListContainer) => void | PromiseLike<void>'.
  Types of parameters 'value' and 'value' are incompatible.
    Type 'TokenListContainer' is not assignable to type 'SetStateAction<TokenListContainer | null>'.
      Type 'import("/Users/sluscher/Documents/Programming/metaplex/js/node_modules/@solana/spl-token-registry/dist/main/lib/tokenlist").TokenListContainer' is not assignable to type 'import("/Users/sluscher/Documents/Programming/metaplex/js/packages/web/node_modules/@solana/spl-token-registry/dist/main/lib/tokenlist").TokenListContainer'.
        Types have separate declarations of a private property 'tokenList'.
```

To sidestep this problem entirely, we just _use the actual return type of `getTokenListContainerPromise` in the generic of `useState`. Now there's no confusion what state will get set where and when.

## Test plan:

```
yarn build
```