### PR TITLE
Respect chosen cluster when fetching tokens (take 2)

### DIFF
--- a/js/packages/web/src/components/AuctionCard/index.tsx
+++ b/js/packages/web/src/components/AuctionCard/index.tsx
@@ -242,7 +242,7 @@ export const AuctionCard = ({
 
   const mintKey = auctionView.auction.info.tokenMint;
   const balance = useUserBalance(mintKey);
-  const tokenInfo = useTokenList().mainnetTokens.filter(
+  const tokenInfo = useTokenList().subscribedTokens.filter(
     m => m.address == mintKey,
   )[0];
   const symbol = tokenInfo

--- a/js/packages/web/src/components/AuctionNumbers/index.tsx
+++ b/js/packages/web/src/components/AuctionNumbers/index.tsx
@@ -53,7 +53,7 @@ export const AuctionNumbers = (props: {
   const isUpcoming = auctionView.state === AuctionViewState.Upcoming;
   const isStarted = auctionView.state === AuctionViewState.Live;
 
-  const tokenInfo = useTokenList().mainnetTokens.filter(m=>m.address == auctionView.auction.info.tokenMint)[0]
+  const tokenInfo = useTokenList().subscribedTokens.filter(m=>m.address == auctionView.auction.info.tokenMint)[0]
   const ended = isEnded(state);
 
   return (

--- a/js/packages/web/src/components/AuctionRenderCard/index.tsx
+++ b/js/packages/web/src/components/AuctionRenderCard/index.tsx
@@ -20,7 +20,7 @@ export const AuctionRenderCard = (props: AuctionCard) => {
   const creators = useCreators(auctionView);
   const name = art?.title || ' ';
 
-  const tokenInfo = useTokenList().mainnetTokens.filter(m=>m.address == auctionView.auction.info.tokenMint)[0]
+  const tokenInfo = useTokenList().subscribedTokens.filter(m=>m.address == auctionView.auction.info.tokenMint)[0]
   const { status, amount } = useAuctionStatus(auctionView);
 
   const card = (

--- a/js/packages/web/src/components/FundsIssueModal/index.tsx
+++ b/js/packages/web/src/components/FundsIssueModal/index.tsx
@@ -12,7 +12,7 @@ export const FundsIssueModal = (props: {
   onClose: () => void
 }) => {
   const {currentFunds: balance, minimumFunds, message} = props
-  const tokenInfo = useTokenList().mainnetTokens.filter(m=>m.address == WRAPPED_SOL_MINT.toBase58())[0]
+  const tokenInfo = useTokenList().subscribedTokens.filter(m=>m.address == WRAPPED_SOL_MINT.toBase58())[0]
   return (
       <MetaplexModal
         title={"Transaction Alert"}

--- a/js/packages/web/src/components/TokenDialog/index.tsx
+++ b/js/packages/web/src/components/TokenDialog/index.tsx
@@ -24,7 +24,7 @@ export function TokenButton({
   mint: PublicKey;
   onClick: () => void;
 }) {
-  const tokenMap = useTokenList().mainnetTokens;
+  const tokenMap = useTokenList().subscribedTokens;
   let tokenInfo = tokenMap.filter(t => t.address == mint.toBase58())[0];
 
   return (

--- a/js/packages/web/src/contexts/coingecko.tsx
+++ b/js/packages/web/src/contexts/coingecko.tsx
@@ -36,7 +36,7 @@ const CoingeckoContext =
 export function CoingeckoProvider({ children = null as any }) {
   const [solPrice, setSolPrice] = useState<number>(0);
   const [allSplPrices, setAllSplPrices] = useState<AllSplTokens[]>([]);
-  const tokenList = useTokenList().mainnetTokens
+  const tokenList = useTokenList().subscribedTokens
 
   useEffect(() => {
     let timerId = 0;

--- a/js/packages/web/src/contexts/tokenList.tsx
+++ b/js/packages/web/src/contexts/tokenList.tsx
@@ -10,7 +10,7 @@ export const SPL_REGISTRY_SOLLET_TAG = "wrapped-sollet";
 export const SPL_REGISTRY_WORM_TAG = "wormhole";
 
 export interface TokenListContextState {
-  mainnetTokens: TokenInfo[];
+  subscribedTokens: TokenInfo[];
   tokenMap: Map<string, TokenInfo>;
   wormholeMap: Map<string, TokenInfo>;
   solletMap: Map<string, TokenInfo>;
@@ -42,12 +42,12 @@ export function SPLTokenListProvider({ children = null as any }) {
   const hasOtherTokens = !!process.env.NEXT_SPL_TOKEN_MINTS;
 
   // Added tokenList to know in which currency the auction is (SOL or other SPL)
-  const mainnetTokens = tokenList?tokenList.filterByClusterSlug("mainnet-beta").getList().filter(f=> subscribedTokenMints.some(s=> s == f.address) )
+  const subscribedTokens = tokenList?tokenList.filterByClusterSlug("mainnet-beta").getList().filter(f=> subscribedTokenMints.some(s=> s == f.address) )
     :[]
 
   const tokenMap = useMemo(() => {
     const tokenMap = new Map();
-    mainnetTokens.forEach((t: TokenInfo) => {
+    subscribedTokens.forEach((t: TokenInfo) => {
       tokenMap.set(t.address, t);
     });
     return tokenMap;
@@ -55,7 +55,7 @@ export function SPLTokenListProvider({ children = null as any }) {
 
   // Tokens with USD(x) quoted markets.
   const swappableTokens = useMemo(() => {
-    const tokens = mainnetTokens.filter((t: TokenInfo) => {
+    const tokens = subscribedTokens.filter((t: TokenInfo) => {
       const isUsdxQuoted =
         t.extensions?.serumV3Usdt || t.extensions?.serumV3Usdc;
       return isUsdxQuoted;
@@ -68,7 +68,7 @@ export function SPLTokenListProvider({ children = null as any }) {
 
   // Sollet wrapped tokens.
   const [swappableTokensSollet, solletMap] = useMemo(() => {
-    const tokens = mainnetTokens.filter((t: TokenInfo) => {
+    const tokens = subscribedTokens.filter((t: TokenInfo) => {
       const isSollet = t.tags?.includes(SPL_REGISTRY_SOLLET_TAG);
       return isSollet;
     });
@@ -83,7 +83,7 @@ export function SPLTokenListProvider({ children = null as any }) {
 
   // Wormhole wrapped tokens.
   const [swappableTokensWormhole, wormholeMap] = useMemo(() => {
-    const tokens = mainnetTokens.filter((t: TokenInfo) => {
+    const tokens = subscribedTokens.filter((t: TokenInfo) => {
       const isSollet = t.tags?.includes(SPL_REGISTRY_WORM_TAG);
       return isSollet;
     });
@@ -98,7 +98,7 @@ export function SPLTokenListProvider({ children = null as any }) {
 
   return (
     <TokenListContext.Provider value={{
-      mainnetTokens,
+      subscribedTokens,
       tokenMap,
       wormholeMap,
       solletMap,
@@ -123,9 +123,9 @@ export const useSwappableTokens = () => {
 }
 
 export const queryTokenList = () => {
-  const { mainnetTokens } = useTokenList();
+  const { subscribedTokens } = useTokenList();
 
-  return mainnetTokens;
+  return subscribedTokens;
 };
 
 export const useTokenList = () => {

--- a/js/packages/web/src/views/auction/index.tsx
+++ b/js/packages/web/src/views/auction/index.tsx
@@ -110,7 +110,7 @@ export const AuctionView = () => {
   const description = data?.description;
   const attributes = data?.attributes;
 
-  const tokenInfo = useTokenList()?.mainnetTokens.filter(
+  const tokenInfo = useTokenList()?.subscribedTokens.filter(
     m => m.address == auction?.auction.info.tokenMint,
   )[0];
 
@@ -435,7 +435,7 @@ const BidLine = (props: {
   const { publicKey } = useWallet();
   const bidder = bid.info.bidderPubkey;
   const isme = publicKey?.toBase58() === bidder;
-  const tokenInfo = useTokenList().mainnetTokens.filter(
+  const tokenInfo = useTokenList().subscribedTokens.filter(
     m => m.address == mintKey,
   )[0];
 


### PR DESCRIPTION
This is a rebased new attempt for @stegaBOB to review after my first attempt on https://github.com/metaplex-foundation/metaplex/pull/1658. Copying description from there but I recommend checking other comments there.

@steveluscher I'd appreciate you take a look too because as part of the rebase I found there's no need anymore for the type-related stuff you had to do a few hours ago in https://github.com/metaplex-foundation/metaplex/pull/1728. So I removed it. But I'm no Typescript expert so I'm open for feedback. Please note the reason it's not needed anymore is because `getTokenListContainerPromise` is not directly used from the `tokenList.tsx` file anymore, but still indirectly used through `useConnectionConfig()`, so your work on caching the list is still leveraged.

---

I'm not sure why the list of SPL Tokens was hardcoded to be fetched from `mainnet-beta`, instead of respecting the same endpoint being used in the global connection and chosen from the UI/LocalStorage/param. I asked about this in the #storefront Discord channel but didn't get a response.

With this PR, the list of SPL Tokens is filtered by whatever cluster is chosen by the user and not always `mainnet-beta`.

If there's a reason this was hardcoded maybe it's a good idea to add a comment in the code about it. But I saw no reason for it.

Most of the changes are just a rename of variables from `mainnetTokens` to `subscribedTokens` to make it less cluster-specific and more semantic.

The real change is to reuse the already filtered by chain id list of tokens coming from the connection instead of using a hardcoded filter by cluster name.