### PR TITLE
CandyMachine 1.9.5 Fix

### DIFF
--- a/js/packages/candy-machine-ui/src/candy-machine.ts
+++ b/js/packages/candy-machine-ui/src/candy-machine.ts
@@ -37,7 +37,7 @@ interface CandyMachineState {
   };
   endSettings: null | {
     number: anchor.BN;
-    endSettingType: any
+    endSettingType: any;
   };
   whitelistMintSettings: null | {
     mode: any;
@@ -438,7 +438,7 @@ export const mintOneToken = async (
         systemProgram: SystemProgram.programId,
         rent: anchor.web3.SYSVAR_RENT_PUBKEY,
         clock: anchor.web3.SYSVAR_CLOCK_PUBKEY,
-        recentBlockhashes: anchor.web3.SYSVAR_RECENT_BLOCKHASHES_PUBKEY,
+        recentBlockhashes: anchor.web3.SYSVAR_SLOT_HASHES_PUBKEY,
         instructionSysvarAccount: anchor.web3.SYSVAR_INSTRUCTIONS_PUBKEY,
       },
       remainingAccounts:

--- a/js/packages/cli/package.json
+++ b/js/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metaplex/cli",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "./build/cli.js",
   "license": "MIT",
   "scripts": {
@@ -35,6 +35,7 @@
     ]
   },
   "dependencies": {
+    "@solana/web3.js": "1.33.0",
     "@aws-sdk/client-s3": "^3.36.0",
     "@bundlr-network/client": "^0.5.9",
     "@metaplex/arweave-cost": "^1.0.4",

--- a/js/packages/cli/src/commands/mint.ts
+++ b/js/packages/cli/src/commands/mint.ts
@@ -332,7 +332,7 @@ export async function mintV2(
         systemProgram: SystemProgram.programId,
         rent: anchor.web3.SYSVAR_RENT_PUBKEY,
         clock: anchor.web3.SYSVAR_CLOCK_PUBKEY,
-        recentBlockhashes: anchor.web3.SYSVAR_RECENT_BLOCKHASHES_PUBKEY,
+        recentBlockhashes: anchor.web3.SYSVAR_SLOT_HASHES_PUBKEY,
         instructionSysvarAccount: anchor.web3.SYSVAR_INSTRUCTIONS_PUBKEY,
       },
       remainingAccounts:

--- a/js/packages/cli/src/helpers/constants.ts
+++ b/js/packages/cli/src/helpers/constants.ts
@@ -21,7 +21,6 @@ export const CANDY_MACHINE_PROGRAM_ID = new PublicKey(
 
 export const CANDY_MACHINE_PROGRAM_V2_ID = new PublicKey(
   'cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ',
-  //'Ch3qpQYqr7AvLP6Eph9xxbtneAbzovzuEexAGh48URHS',
 );
 export const TOKEN_METADATA_PROGRAM_ID = new PublicKey(
   'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -5726,7 +5726,7 @@
     "@solana/wallet-adapter-solong" "^0.4.1"
     "@solana/wallet-adapter-torus" "^0.5.0"
 
-"@solana/web3.js@^1.12.0", "@solana/web3.js@^1.17.0", "@solana/web3.js@^1.20.0", "@solana/web3.js@^1.21.0", "@solana/web3.js@^1.24.1", "@solana/web3.js@^1.30.2", "@solana/web3.js@^1.31.0", "@solana/web3.js@^1.32.0":
+"@solana/web3.js@1.33.0", "@solana/web3.js@^1.12.0", "@solana/web3.js@^1.17.0", "@solana/web3.js@^1.20.0", "@solana/web3.js@^1.21.0", "@solana/web3.js@^1.24.1", "@solana/web3.js@^1.30.2", "@solana/web3.js@^1.31.0", "@solana/web3.js@^1.32.0":
   version "1.32.0"
   resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.32.0.tgz#b9821de52d0e773c363516c3dcef9be701295d82"
   integrity sha512-jquZ/VBvM3zXAaTJvdWd9mlP0WiZaZqjji0vw5UAsb5IKIossrLhHtyUqMfo41Qkdwu1aVwf7YWG748i4XIJnw==


### PR DESCRIPTION
Because `recent_blockhashes` a deprecated sysvar was chosen to produce entropy 1.9.5 deployment to devnet bricked the candy machine minting function. This PR is the UI work to fix this. It must be coupled with an incoming MPL PR

https://github.com/metaplex-foundation/metaplex-program-library/pull/202