### PR TITLE
[Proposal] append mint_number to metadata uri

### DIFF
--- a/js/packages/cli/src/helpers/constants.ts
+++ b/js/packages/cli/src/helpers/constants.ts
@@ -20,7 +20,8 @@ export const CANDY_MACHINE_PROGRAM_ID = new PublicKey(
 );
 
 export const CANDY_MACHINE_PROGRAM_V2_ID = new PublicKey(
-  'cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ',
+  '8VRwdyLCnj3KYuKpsEuWZqyaqgTMQ5ESAZEohS5vwBDN',
+  // 'cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ',
   //'Ch3qpQYqr7AvLP6Eph9xxbtneAbzovzuEexAGh48URHS',
 );
 export const TOKEN_METADATA_PROGRAM_ID = new PublicKey(

--- a/js/packages/fair-launch/src/candy-machine.ts
+++ b/js/packages/fair-launch/src/candy-machine.ts
@@ -13,7 +13,8 @@ import {
 } from './utils';
 
 export const CANDY_MACHINE_PROGRAM = new anchor.web3.PublicKey(
-  'cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ',
+  '8VRwdyLCnj3KYuKpsEuWZqyaqgTMQ5ESAZEohS5vwBDN',
+  // 'cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ',
 );
 
 const TOKEN_METADATA_PROGRAM_ID = new anchor.web3.PublicKey(

--- a/rust/nft-candy-machine-v2/src/lib.rs
+++ b/rust/nft-candy-machine-v2/src/lib.rs
@@ -27,7 +27,7 @@ use {
     spl_token::state::Mint,
     std::{cell::RefMut, ops::Deref, str::FromStr},
 };
-anchor_lang::declare_id!("cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ");
+anchor_lang::declare_id!("8VRwdyLCnj3KYuKpsEuWZqyaqgTMQ5ESAZEohS5vwBDN");
 
 const EXPIRE_OFFSET: i64 = 10 * 60;
 const PREFIX: &str = "candy_machine";
@@ -910,7 +910,7 @@ pub fn get_config_line<'info>(
     if let Some(hs) = &a.data.hidden_settings {
         return Ok(ConfigLine {
             name: hs.name.clone() + "#" + &(mint_number + 1).to_string(),
-            uri: hs.uri.clone(),
+            uri: hs.uri.clone() + &(mint_number + 1).to_string(),
         });
     }
     msg!("Index is set to {:?}", index);


### PR DESCRIPTION
As mentioned [here](https://github.com/metaplex-foundation/metaplex/issues/1331)
I've added mint_number in the tail of metadata uri. This makes more sense because nft issuer doesn't have to update every metadata uri for each mint to reveal, which will be cumbersome and wasting transaction fees.

I understand that updating candy machine program will involve many changes to docs and address changes for related programs. But here is the proposal and please let me know what should I do to contribute. Many Thanks.

# Changes
- Append mint_number to metadata uri
- Update program id