### PR TITLE
Candy Machine CLI Improvements

### DIFF
--- a/js/packages/cli/src/candy-machine-v2-cli.ts
+++ b/js/packages/cli/src/candy-machine-v2-cli.ts
@@ -93,7 +93,7 @@ programCommand('upload')
     '-rl, --rate-limit <number>',
     'max number of requests per second',
     myParseInt,
-    10,
+    25,
   )
   .action(async (files: string[], options, cmd) => {
     const { keypair, env, cacheName, configPath, rpcUrl, rateLimit } =

--- a/js/packages/cli/src/candy-machine-v2-cli.ts
+++ b/js/packages/cli/src/candy-machine-v2-cli.ts
@@ -93,7 +93,7 @@ programCommand('upload')
     '-rl, --rate-limit <number>',
     'max number of requests per second',
     myParseInt,
-    25,
+    5,
   )
   .action(async (files: string[], options, cmd) => {
     const { keypair, env, cacheName, configPath, rpcUrl, rateLimit } =

--- a/js/packages/cli/src/commands/upload.ts
+++ b/js/packages/cli/src/commands/upload.ts
@@ -296,12 +296,6 @@ export async function uploadV2({
                 break;
               case StorageType.Arweave:
               default:
-                // [link, imageLink] = [
-                //   'startlink link link link link: ' +
-                //   assetKey.index +
-                //   'endlink',
-                //   'linklinklink',
-                // ];
                 uploadPromise.push(() =>
                   arweaveUpload(
                     walletKeyPair,
@@ -465,8 +459,19 @@ async function writeIndices({
   try {
     let promiseArray = [];
     const allIndexesInSlice = Array.from(Array(keys.length).keys());
-    for (let offset = 0; offset < allIndexesInSlice.length; offset += 10) {
-      const indexes = allIndexesInSlice.slice(offset, offset + 10);
+    let offset = 0;
+    while (offset < allIndexesInSlice.length) {
+      let length = 0;
+      let index = 0;
+      let indexes = allIndexesInSlice.slice(offset, offset + 16);
+      while (length < 850 && index < 16 && indexes[index] !== undefined) {
+        length +=
+          cacheContent.items[keys[indexes[index]]].link.length +
+          cacheContent.items[keys[indexes[index]]].name.length;
+        if (length < 850) index++;
+      }
+      indexes = allIndexesInSlice.slice(offset, offset + index);
+      offset += index;
       const onChain = indexes.filter(i => {
         const index = keys[i];
         return cacheContent.items[index]?.onChain || false;

--- a/js/packages/cli/src/commands/upload.ts
+++ b/js/packages/cli/src/commands/upload.ts
@@ -242,7 +242,16 @@ export async function uploadV2({
 
               let animation = undefined;
               if ('animation_url' in manifest) {
-                animation = path.join(dirname, `${manifest.animation_url}`);
+                const animationPath = path.join(
+                  dirname,
+                  `${manifest.animation_url}`,
+                );
+                if (
+                  fs.existsSync(animationPath) &&
+                  fs.lstatSync(animationPath).isFile()
+                ) {
+                  animation = animationPath;
+                }
               }
 
               const manifestBuffer = Buffer.from(JSON.stringify(manifest));

--- a/js/packages/cli/src/helpers/upload/arweave-bundle.ts
+++ b/js/packages/cli/src/helpers/upload/arweave-bundle.ts
@@ -1,5 +1,4 @@
 import { readFile, stat } from 'fs/promises';
-import { readFileSync } from 'fs';
 import path from 'path';
 import Arweave from 'arweave';
 
@@ -15,6 +14,7 @@ import Transaction from 'arweave/node/lib/transaction';
 import Bundlr from '@bundlr-network/client';
 
 import BundlrTransaction from '@bundlr-network/client/build/src/transaction';
+import { getAssetManifest } from '../../commands/upload';
 
 export const LAMPORTS = 1_000_000_000;
 /**
@@ -483,9 +483,8 @@ export function* makeArweaveBundleUploadGenerator(
 
   const filePairs = assets.map((asset: AssetKey) => {
     const manifestPath = path.join(dirname, `${asset.index}.json`);
-    const manifestData: Manifest = JSON.parse(
-      readFileSync(manifestPath).toString(),
-    );
+    const manifestData = getAssetManifest(dirname, asset.index);
+
     return {
       key: asset.index,
       image: path.join(dirname, `${manifestData.image}`),

--- a/js/packages/cli/test/run-test-v2.sh
+++ b/js/packages/cli/test/run-test-v2.sh
@@ -12,13 +12,13 @@ ENV_URL="devnet"
 RPC="https://psytrbhymqlkfrhudd.dev.genesysgo.net:8899/" # devnet
 STORAGE="arweave"
 
-ITEMS=30
+ITEMS=300
 MULTIPLE=0
 
-RESET="Y"
+RESET="N"
 EXT="png"
-CLOSE="Y"
-CHANGE="Y"
+CLOSE="N"
+CHANGE="N"
 
 ARWEAVE_JWK="null"
 INFURA_ID="null"

--- a/js/packages/cli/test/run-test-v2.sh
+++ b/js/packages/cli/test/run-test-v2.sh
@@ -12,10 +12,10 @@ ENV_URL="devnet"
 RPC="https://psytrbhymqlkfrhudd.dev.genesysgo.net:8899/" # devnet
 STORAGE="arweave"
 
-ITEMS=10
+ITEMS=30
 MULTIPLE=0
 
-RESET="N"
+RESET="Y"
 EXT="png"
 CLOSE="Y"
 CHANGE="Y"

--- a/js/packages/cli/test/run-test-v2.sh
+++ b/js/packages/cli/test/run-test-v2.sh
@@ -4,21 +4,21 @@
 #
 # To suppress prompts, you will need to set/export the following variables:
 #
-# ENV_URL="mainnet-beta"
-# RPC="https://ssc-dao.genesysgo.net/" # mainnet-beta
-# STORAGE="arweave-sol"
+ENV_URL="mainnet-beta"
+RPC="https://ssc-dao.genesysgo.net/" # mainnet-beta
+STORAGE="arweave-sol"
 
-ENV_URL="devnet"
-RPC="https://psytrbhymqlkfrhudd.dev.genesysgo.net:8899/" # devnet
-STORAGE="arweave"
+# ENV_URL="devnet"
+# RPC="https://psytrbhymqlkfrhudd.dev.genesysgo.net:8899/" # devnet
+# STORAGE="arweave"
 
-ITEMS=300
+ITEMS=50
 MULTIPLE=0
 
 RESET="N"
 EXT="png"
-CLOSE="N"
-CHANGE="N"
+CLOSE="Y"
+CHANGE="Y"
 
 ARWEAVE_JWK="null"
 INFURA_ID="null"

--- a/js/packages/cli/test/run-test-v2.sh
+++ b/js/packages/cli/test/run-test-v2.sh
@@ -4,26 +4,27 @@
 #
 # To suppress prompts, you will need to set/export the following variables:
 #
-ENV_URL="mainnet-beta"
-RPC="https://ssc-dao.genesysgo.net/" # mainnet-beta
-STORAGE="arweave-sol"
+# ENV_URL="mainnet-beta"
+# RPC="https://ssc-dao.genesysgo.net/" # mainnet-beta
+# STORAGE="arweave-sol"
 
 # ENV_URL="devnet"
 # RPC="https://psytrbhymqlkfrhudd.dev.genesysgo.net:8899/" # devnet
 # STORAGE="arweave"
 
-ITEMS=50
-MULTIPLE=0
+# ITEMS=10
+# MULTIPLE=0
 
-RESET="N"
-EXT="png"
-CLOSE="Y"
-CHANGE="Y"
+# RESET="Y"
+# EXT="png"
+# CLOSE="Y"
+# CHANGE="Y"
+# TEST_IMAGE="Y"
 
-ARWEAVE_JWK="null"
-INFURA_ID="null"
-INFURA_SECRET="null"
-AWS_BUCKET="null"
+# ARWEAVE_JWK="null"
+# INFURA_ID="null"
+# INFURA_SECRET="null"
+# AWS_BUCKET="null"
 
 # The custom RPC server option can be specified either by the flag -r <url>
 
@@ -64,6 +65,7 @@ CMD_CMV2="ts-node ${SRC_DIR}/candy-machine-v2-cli.ts"
 PNG="https://rm5fm2cz5z4kww2gbyjwhyfekgcc3qjmz43cw53g6qhwhgcofoyq.arweave.net/izpWaFnueKtbRg4TY-CkUYQtwSzPNit3ZvQPY5hOK7E/?ext=png"
 GIF="https://3shhjbznlupbi4gldnfdzpvulcexrek5fovdtzpo37bxde6au5va.arweave.net/3I50hy1dHhRwyxtKPL60WIl4kV0rqjnl7t_DcZPAp2o/?ext=gif"
 JPG="https://7cvkvtes5uh4h3ud42bi3nl2ivtmnbpqppqmau7pk2p2qykkmbya.arweave.net/-KqqzJLtD8Pug-aCjbV6RWbGhfB74MBT71afqGFKYHA/?ext=jpg"
+MP4="https://sdhj7rx52ch7dhe7znokxv2u6mffsalrzuiwxrd5liekkettqpdq.arweave.net/kM6fxv3Qj_Gcn8tcq9dU8wpZAXHNEWvEfVoIpRJzg8c/?ext=mp4"
 
 blu ""
 blu "Candy Machine CLI - Automated Test"
@@ -158,6 +160,7 @@ fi
 
 # Asset type
 
+ANIMATION=0
 if [ -z ${EXT+x} ]; then
     IMAGE=$PNG
     EXT="png"
@@ -166,6 +169,7 @@ if [ -z ${EXT+x} ]; then
     echo "1. PNG (default)"
     echo "2. JPG"
     echo "3. GIF"
+    echo "4. MP4"
     echo -n "Select the file type [1-3] (default 1): "
     read Input
     case "$Input" in
@@ -181,6 +185,11 @@ if [ -z ${EXT+x} ]; then
         IMAGE=$GIF
         EXT="gif"
         ;;
+    4)
+        IMAGE=$PNG
+        EXT="png"
+        ANIMATION=1
+        ;;
     esac
 else
     case "$EXT" in
@@ -192,6 +201,11 @@ else
         ;;
     gif)
         IMAGE=$GIF
+        ;;
+    mp4)
+        IMAGE=$PNG
+        EXT="png"
+        ANIMATION=1
         ;;
     *)
         red "[$(date "+%T")] Aborting: invalid asset type ${EXT}"
@@ -212,6 +226,17 @@ if [ -z ${ITEMS+x} ]; then
     else
         # make sure we are dealing with a number
         ITEMS=$(($Number + 0))
+    fi
+fi
+
+# Test image.extension instead of index
+
+if [ -z ${TEST_IMAGE+x} ]; then
+    echo ""
+    echo -n "$(cyn "Test image.ext replacement [Y/n]") (default 'Y'): "
+    read TEST_IMAGE
+    if [ -z "$TEST_IMAGE" ]; then
+        TEST_IMAGE="Y"
     fi
 fi
 
@@ -270,7 +295,7 @@ if [ "${RESET}" = "Y" ]; then
     rm -rf .cache 2>/dev/null
 fi
 
-# Creation of the collection. This will generate ITEMS x (json, image)
+# Creation of the collection. This will generate ITEMS x (json, image, animation?)
 # files in the ASSETS_DIR
 
 # preparing the assets to upload
@@ -280,7 +305,7 @@ read -r -d '' METADATA <<-EOM
     "symbol": "TEST",
     "description": "Candy Machine CLI Test #%s",
     "seller_fee_basis_points": 500,
-    "image": "%s.%s",
+    "image": "%s.%s",%b
     "attributes": [{"trait_type": "Background", "value": "True"}],
     "properties": {
         "creators": [
@@ -288,16 +313,24 @@ read -r -d '' METADATA <<-EOM
             "address": "$(solana address)",
             "share": 100
         }],
-        "files": [{"uri":"%s.%s", "type":"image/%s"}]
-    },
-    "collection": { "name": "Candy Machine CLI", "family": "Candy Machine CLI"}
+        "files": []
+    }
 }
 EOM
 
 if [ ! -d $ASSETS_DIR ]; then
     mkdir $ASSETS_DIR
-    curl -s $IMAGE >"$ASSETS_DIR/template.$EXT"
-    SIZE=$(wc -c "$ASSETS_DIR/template.$EXT" | grep -oE '[0-9]+' | head -n 1)
+    if [ "$ANIMATION" -eq 1 ]; then
+        curl -s $MP4 >"$ASSETS_DIR/template_animation.mp4"
+        SIZE=$(wc -c "$ASSETS_DIR/template_animation.mp4" | grep -oE '[0-9]+' | head -n 1)
+
+        if [ $SIZE -eq 0 ]; then
+            red "[$(date "+%T")] Aborting: could not download sample mp4"
+            exit 1
+        fi
+    fi
+    curl -s $IMAGE >"$ASSETS_DIR/template_image.$EXT"
+    SIZE=$(wc -c "$ASSETS_DIR/template_image.$EXT" | grep -oE '[0-9]+' | head -n 1)
 
     if [ $SIZE -eq 0 ]; then
         red "[$(date "+%T")] Aborting: could not download sample image"
@@ -306,11 +339,21 @@ if [ ! -d $ASSETS_DIR ]; then
 
     # initialises the assets - this will be multiple copies of the same
     # image/json pair with a new index
+    INDEX="image"
     for ((i = 0; i < $ITEMS; i++)); do
-        printf "$METADATA" $i $i $i $EXT $i $EXT $EXT >"$ASSETS_DIR/$i.json"
-        cp "$ASSETS_DIR/template.$EXT" "$ASSETS_DIR/$i.$EXT"
+        if [ ! "$TEST_IMAGE" = "Y" ]; then
+            INDEX=$i
+        fi
+        cp "$ASSETS_DIR/template_image.$EXT" "$ASSETS_DIR/$i.$EXT"
+        if [ "$ANIMATION" = 1 ]; then
+            cp "$ASSETS_DIR/template_animation.mp4" "$ASSETS_DIR/$i.mp4"
+            printf "$METADATA" $i $i $INDEX $EXT "\r\t\"animation_url\": \"$i.mp4\"," >"$ASSETS_DIR/$i.json"
+        else
+            printf "$METADATA" $i $i $INDEX $EXT "" >"$ASSETS_DIR/$i.json"
+        fi
     done
-    rm "$ASSETS_DIR/template.$EXT"
+    rm "$ASSETS_DIR/template_image.$EXT"
+    rm "$ASSETS_DIR/template_animation.mp4"
 fi
 
 # Candy Machine configuration

--- a/js/packages/cli/test/run-test-v2.sh
+++ b/js/packages/cli/test/run-test-v2.sh
@@ -412,36 +412,6 @@ function change_cache {
     fi
 }
 
-# check on chain config to make sure everything is correct
-function check_changed {
-    CANDY="$(cat $CACHE_FILE | jq -c -r ".program.candyMachine")"
-    LAST_LINK="$(cat $CACHE_FILE | jq -c -r ".items.\""$LAST_INDEX"\".link")"
-    echo "$(grn "Candy Machine Id:") $CANDY"
-    echo "$(grn "Changed Link:") $LAST_LINK"
-    temp_file=$(mktemp)
-    echo $CANDY | xargs -I{} solana account {} -u $RPC -o $temp_file
-
-    FAILED=0
-    for ((i = 0; i <= $LAST_INDEX; i++)); do
-        LINK="$(cat $CACHE_FILE | jq -c -r ".items.\""$i"\".link")"
-        if [[ $(($i % $(($LAST_INDEX / 20)))) -eq 0 ]]; then
-            echo -ne "\033[2K\r"
-            echo -ne $cyn"Checked $i of $(($LAST_INDEX + 1))"$white
-        fi
-        if [[ ! $(strings $temp_file | grep -a "$LINK") ]]; then
-            # red "Failure: item $i not found on chain"
-            FAILED=$(($FAILED + 1))
-        fi
-    done
-    echo -ne "\033[2K\r"
-    if [[ $(($FAILED)) -eq 0 ]]; then
-        echo -e $grn"Success: all $(($LAST_INDEX + 1)) items found on chain"$white
-    else
-        echo -e $red"Failure: $FAILED out of $(($LAST_INDEX + 1)) items were not found on chain"$white
-    fi
-
-}
-
 # run the verify upload command
 function verify_upload {
     $CMD_CMV2 verify_upload --keypair $WALLET_KEY --env $ENV_URL -c $CACHE_NAME -r $RPC
@@ -486,7 +456,6 @@ if [ "${CHANGE}" = "Y" ]; then
     change_cache
     upload
     verify_upload
-    check_changed
     mag "<<<"
 else
     blu "Skipping 3 (Editing cache and testing reupload)"


### PR DESCRIPTION
This PR fixes a number of issues with the CM CLI and improves upload performance drastically.

- Replaces `image.extension` with `index.extension` in arweave-sol (regression from animation support PR)
- Makes the `writeIndices` on-chain function fully async (significantly improves performance)
- Number of assets written on chain per txn is now variable, improving performance and solving #1803
- Checks if file in animation_url exists before setting animation type to true, fixing #1804
- Improves test script quite a bit. New version greps the file in each index to make sure it actually is all on chain. Also now supports animation type testing and image.ext replacement testing. 
- Removes the grep function that was added in this PR because it is actually pointless and doesn't make any sense to add. 

**TODO:**

- [x] Run a few more tests. Make sure it's stable
