### PR TITLE
fix: Changed deprecated 'randomness-oracle' usage to solana 'SlotHash' sysvar.

### DIFF
--- a/js/packages/common/src/models/packs/instructions/claimPack.ts
+++ b/js/packages/common/src/models/packs/instructions/claimPack.ts
@@ -6,7 +6,6 @@ import {
 } from '@solana/web3.js';
 import { serialize } from 'borsh';
 import BN from 'bn.js';
-
 import { programIds, toPublicKey, StringPublicKey } from '../../../utils';
 import {
   ClaimPackArgs,
@@ -30,7 +29,6 @@ interface Params extends ClaimPackParams {
   newMint: StringPublicKey;
   metadataMint: StringPublicKey;
   edition: BN;
-  randomOracle: StringPublicKey;
 }
 
 export async function claimPack({
@@ -42,7 +40,6 @@ export async function claimPack({
   newMint,
   metadataMint,
   edition,
-  randomOracle,
 }: Params): Promise<TransactionInstruction> {
   const PROGRAM_IDS = programIds();
   const value = new ClaimPackArgs({ index });
@@ -156,21 +153,15 @@ export async function claimPack({
       isSigner: false,
       isWritable: false,
     },
-    // randomness_oracle
-    {
-      pubkey: toPublicKey(randomOracle),
-      isSigner: false,
-      isWritable: false,
-    },
     // metaplex_token_metadata
     {
-      pubkey: toPublicKey(programIds().metadata),
+      pubkey: toPublicKey(PROGRAM_IDS.metadata),
       isSigner: false,
       isWritable: false,
     },
     // spl_token program
     {
-      pubkey: programIds().token,
+      pubkey: PROGRAM_IDS.token,
       isSigner: false,
       isWritable: false,
     },

--- a/js/packages/common/src/models/packs/instructions/initPackSet.ts
+++ b/js/packages/common/src/models/packs/instructions/initPackSet.ts
@@ -5,7 +5,6 @@ import {
   SYSVAR_CLOCK_PUBKEY,
 } from '@solana/web3.js';
 import { serialize } from 'borsh';
-
 import { getWhitelistedCreator } from '../../metaplex';
 import { programIds, toPublicKey, StringPublicKey } from '../../../utils';
 import { InitPackSetParams } from '../interface';
@@ -62,11 +61,6 @@ export async function initPackSet({
     },
     {
       pubkey: toPublicKey(store),
-      isSigner: false,
-      isWritable: false,
-    },
-    {
-      pubkey: PROGRAM_IDS.oracle,
       isSigner: false,
       isWritable: false,
     },

--- a/js/packages/common/src/models/packs/instructions/requestCardToRedeem.ts
+++ b/js/packages/common/src/models/packs/instructions/requestCardToRedeem.ts
@@ -6,7 +6,6 @@ import {
   SystemProgram,
 } from '@solana/web3.js';
 import { serialize } from 'borsh';
-
 import { programIds, toPublicKey, StringPublicKey } from '../../../utils';
 import { PACKS_SCHEMA, RequestCardToRedeemArgs } from '../../..';
 import { RequestCardToRedeemParams } from '..';
@@ -22,7 +21,6 @@ interface Params extends RequestCardToRedeemParams {
   voucherKey: StringPublicKey;
   tokenAccount?: StringPublicKey;
   wallet: PublicKey;
-  randomOracle: StringPublicKey;
 }
 
 export async function requestCardToRedeem({
@@ -33,7 +31,6 @@ export async function requestCardToRedeem({
   voucherKey,
   tokenAccount,
   wallet,
-  randomOracle,
 }: Params): Promise<TransactionInstruction> {
   const PROGRAM_IDS = programIds();
 
@@ -103,9 +100,9 @@ export async function requestCardToRedeem({
       isSigner: true,
       isWritable: true,
     },
-    // randomness_oracle
+    // slot hash
     {
-      pubkey: toPublicKey(randomOracle),
+      pubkey: toPublicKey(PROGRAM_IDS.oracle),
       isSigner: false,
       isWritable: false,
     },
@@ -123,7 +120,7 @@ export async function requestCardToRedeem({
     },
     // spl_token program
     {
-      pubkey: programIds().token,
+      pubkey: PROGRAM_IDS.token,
       isSigner: false,
       isWritable: false,
     },

--- a/js/packages/common/src/utils/ids.ts
+++ b/js/packages/common/src/utils/ids.ts
@@ -82,7 +82,7 @@ export const PACK_CREATE_ID = new PublicKey(
 );
 
 export const ORACLE_ID = new PublicKey(
-  'rndshKFf48HhGaPbaCd3WQYtgCNKzRgVQ3U2we4Cvf9',
+  'SysvarS1otHashes111111111111111111111111111',
 );
 
 export const SYSTEM = new PublicKey('11111111111111111111111111111111');

--- a/js/packages/web/src/views/pack/transactions/claimPackCards.ts
+++ b/js/packages/web/src/views/pack/transactions/claimPackCards.ts
@@ -67,7 +67,6 @@ const claimSeveralCardsByIndex = async ({
   masterEditions,
 }: ClaimSeveralCardsByIndexParams): Promise<GenerateTransactionsResponse[]> => {
   const packSetKey = pack.pubkey;
-  const randomOracle = pack.info.randomOracle;
 
   const packCardToRedeem = await findPackCardProgramAddress(
     toPublicKey(packSetKey),
@@ -96,7 +95,6 @@ const claimSeveralCardsByIndex = async ({
         connection,
         index,
         packSetKey,
-        randomOracle,
         userToken,
         voucherMint,
         metadataMint: packCardMetadata.info.mint,
@@ -111,7 +109,6 @@ const generateClaimPackInstructions = async ({
   connection,
   index,
   packSetKey,
-  randomOracle,
   userToken,
   voucherMint,
   metadataMint,
@@ -136,7 +133,6 @@ const generateClaimPackInstructions = async ({
     newMint,
     metadataMint,
     edition,
-    randomOracle,
   });
 
   return {

--- a/js/packages/web/src/views/pack/transactions/interface.ts
+++ b/js/packages/web/src/views/pack/transactions/interface.ts
@@ -36,7 +36,6 @@ export interface GenerateClaimPackInstructionsParams {
   connection: Connection;
   index: number;
   packSetKey: StringPublicKey;
-  randomOracle: StringPublicKey;
   userToken: StringPublicKey;
   voucherMint: StringPublicKey;
   metadataMint: StringPublicKey;


### PR DESCRIPTION
# Notes
This PR introduce changes for actions related to `nft-packs` program that allow use `SlotHash` sysvar according to on-chain program approach for random values generation.

# Changes
- Changed `ORACLE_ID` to `SlotHash` sysvar id.
- Removed `ORACLE` in places where it should not be used.

# Errors
Currently `DataV2` initialization is broken when trying to create NFT, introduced in [this](https://github.com/metaplex-foundation/metaplex/commit/807935e3b1188fa1c30e82c04658e791a5862544) commit.