### PR TITLE
Fix claiming button issues

### DIFF
--- a/js/packages/web/src/components/AuctionCard/index.tsx
+++ b/js/packages/web/src/components/AuctionCard/index.tsx
@@ -486,7 +486,10 @@ export const AuctionCard = ({
   const isOpenEditionSale =
     auctionView.auction.info.bidState.type === BidStateType.OpenEdition;
 
-  const isBidderPotEmpty = Boolean(auctionView.myBidderPot?.info.emptied);
+  const isBidderPotEmpty = Boolean(
+    // If I haven't bid, myBidderPot should be empty
+    !auctionView.myBidderPot || auctionView.myBidderPot?.info.emptied,
+  );
   const doesInstantSaleHasNoItems =
     isBidderPotEmpty &&
     auctionView.auction.info.bidState.max.toNumber() === bids.length;
@@ -495,7 +498,9 @@ export const AuctionCard = ({
     !isOpenEditionSale &&
     auctionView.isInstantSale &&
     isAuctionManagerAuthorityNotWalletOwner &&
-    doesInstantSaleHasNoItems;
+    doesInstantSaleHasNoItems &&
+    // If your bidderpot is empty but you haven't claimed
+    !canClaimPurchasedItem;
 
   const shouldHide =
     shouldHideInstantSale ||

--- a/js/packages/web/src/styles/app.less
+++ b/js/packages/web/src/styles/app.less
@@ -365,6 +365,7 @@ model-viewer {
     & > div {
       flex: calc(33% - 20px);
       max-width: calc(33% - 20px);
+      max-height: 100%;
     }
   }
 }

--- a/js/packages/web/src/views/auction/index.tsx
+++ b/js/packages/web/src/views/auction/index.tsx
@@ -416,7 +416,7 @@ export const AuctionView = () => {
           {auction && (
             <AuctionCard auctionView={auction} hideDefaultAction={false} />
           )}
-          {!auction?.isInstantSale && <AuctionBids auctionView={auction} />}
+          <AuctionBids auctionView={auction} />
         </Col>
       </Row>
     );
@@ -651,7 +651,9 @@ export const AuctionBids = ({
   return (
     <Row>
       <Col className="bids-lists">
-        <h6 className={'info-title'}>Bid History</h6>
+        <h6 className={'info-title'}>
+          {auctionView.isInstantSale ? 'Sale' : 'Bid'} History
+        </h6>
         {bidLines.slice(0, 10)}
         {bids.length > 10 && (
           <div

--- a/js/packages/web/src/views/auctionCreate/AuctionItemCard.tsx
+++ b/js/packages/web/src/views/auctionCreate/AuctionItemCard.tsx
@@ -53,11 +53,7 @@ const AuctionItemCard = ({
       pubkey={current.metadata.pubkey}
       preview={false}
       onClick={onSelect}
-      className={
-        isSelected
-          ? 'selected-card art-card-for-selector'
-          : 'not-selected-card art-card-for-selector'
-      }
+      className={isSelected ? 'selected-card' : 'not-selected-card'}
       onClose={onClose}
     />
   );

--- a/js/packages/web/src/views/auctionCreate/artSelector.tsx
+++ b/js/packages/web/src/views/auctionCreate/artSelector.tsx
@@ -86,7 +86,7 @@ export const ArtSelector = (props: ArtSelectorProps) => {
           className="content-action"
           style={{ overflowY: 'auto', height: '50vh' }}
         >
-          <div className="artwork-grid">
+          <div className="artwork-grid" style={{ maxHeight: '50%' }}>
             {items.map(m => {
               const id = m.metadata.pubkey;
               const isSelected = selectedItems.has(id);

--- a/js/packages/web/src/views/auctionCreate/artSelector.tsx
+++ b/js/packages/web/src/views/auctionCreate/artSelector.tsx
@@ -112,12 +112,14 @@ export const ArtSelector = (props: ArtSelectorProps) => {
               };
 
               return (
-                <AuctionItemCard
-                  key={id}
-                  isSelected={isSelected}
-                  current={m}
-                  onSelect={onSelect}
-                />
+                <div key={id}>
+                  <AuctionItemCard
+                    key={id}
+                    isSelected={isSelected}
+                    current={m}
+                    onSelect={onSelect}
+                  />
+                </div>
               );
             })}
           </div>


### PR DESCRIPTION
- Fixes artSelector style
- There is an edgecase where your bidderPot is empty and the instant sale has no items but you haven't claimed, the claim button disappears. Fixed that
- Don't show Buy now button if there is nothing to buy
- Display Sale history for instant sale (changed name to Sale History)

![image](https://user-images.githubusercontent.com/25460766/154604083-a7391d3b-69e3-437f-b569-0a237d4750e5.png)
