### PR TITLE
Updated @solana/web3.js to version 1.35.0

### DIFF
--- a/js/packages/candy-machine-ui/package.json
+++ b/js/packages/candy-machine-ui/package.json
@@ -14,7 +14,7 @@
     "@solana/wallet-adapter-react": "^0.13.1",
     "@solana/wallet-adapter-react-ui": "^0.6.1",
     "@solana/wallet-adapter-wallets": "^0.11.3",
-    "@solana/web3.js": "^1.33.0",
+    "@solana/web3.js": "^1.35.0",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",


### PR DESCRIPTION
This Pull Request updates @solana/web3.js in "candy-machine-ui" to the latest version. 

The latest version of @solana/web3.js exports "SYSVAR_SLOT_HASHES_PUBKEY" which is now required in "candy-machine.ts" located in the above mentioned folder.