### PR TITLE
Adds workflow to automatically remove needs more info label

### DIFF
--- a/.github/workflows/needs-information-issue.yml
+++ b/.github/workflows/needs-information-issue.yml
@@ -1,16 +1,15 @@
-name: 'Remove "needs more information"'
+name: Remove needs more information
 on: 
-  workflow_dispatch:
   issue_comment:
     types: [created]
 jobs:
   issue_commented:
     if: ${{ !github.event.issue.pull_request && github.event.issue.user.login == github.event.comment.user.login }}
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
     steps:
-        uses: andymckay/labeler@5c59dabdfd4dd5bd9c6e6d255b01b9d764af4414
+      - uses: andymckay/labeler@5c59dabdfd4dd5bd9c6e6d255b01b9d764af4414
         with:
           remove-labels: "needs more information"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+permissions:
+  issues: write

--- a/.github/workflows/needs-information-issue.yml
+++ b/.github/workflows/needs-information-issue.yml
@@ -1,0 +1,16 @@
+name: 'Remove "needs more information"'
+on: 
+  workflow_dispatch:
+  issue_comment:
+    types: [created]
+jobs:
+  issue_commented:
+    if: ${{ !github.event.issue.pull_request && github.event.issue.user.login == github.event.comment.user.login }}
+    runs-on: ubuntu-latest
+      permissions:
+        issues: write
+      steps:
+          uses: andymckay/labeler@5c59dabdfd4dd5bd9c6e6d255b01b9d764af4414
+          with:
+            remove-labels: "needs more information"
+            repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/needs-information-issue.yml
+++ b/.github/workflows/needs-information-issue.yml
@@ -7,10 +7,10 @@ jobs:
   issue_commented:
     if: ${{ !github.event.issue.pull_request && github.event.issue.user.login == github.event.comment.user.login }}
     runs-on: ubuntu-latest
-      permissions:
-        issues: write
-      steps:
-          uses: andymckay/labeler@5c59dabdfd4dd5bd9c6e6d255b01b9d764af4414
-          with:
-            remove-labels: "needs more information"
-            repo-token: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      issues: write
+    steps:
+        uses: andymckay/labeler@5c59dabdfd4dd5bd9c6e6d255b01b9d764af4414
+        with:
+          remove-labels: "needs more information"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/needs-information-issue.yml
+++ b/.github/workflows/needs-information-issue.yml
@@ -13,3 +13,4 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 permissions:
   issues: write
+  

--- a/.github/workflows/needs-information-issue.yml
+++ b/.github/workflows/needs-information-issue.yml
@@ -7,7 +7,7 @@ jobs:
     if: ${{ !github.event.issue.pull_request && github.event.issue.user.login == github.event.comment.user.login }}
     runs-on: ubuntu-latest
     steps:
-      - uses: andymckay/labeler@5c59dabdfd4dd5bd9c6e6d255b01b9d764af4414
+      - uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90
         with:
           remove-labels: "needs more information"
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The "needs more information" label was created to indicate that the issue is waiting on the issue author to provide more information. This PR adds a workflow that automatically runs and removes the "needs more information" label when the author comments on their own issue that has the label on it. 

TLDR, makes Sammy's work a lot easier to do. 