### PR TITLE
correct address for NFT snapshot in `update_existing_nfts_from_latest_cache_file`

### DIFF
--- a/js/packages/cli/src/commands/updateFromCache.ts
+++ b/js/packages/cli/src/commands/updateFromCache.ts
@@ -17,10 +17,7 @@ import {
   METADATA_SCHEMA,
   UpdateMetadataArgs,
 } from '../helpers/schema';
-import {
-  getCandyMachineCreator,
-  deriveCandyMachineV2ProgramAddress,
-} from '../helpers/accounts';
+import { deriveCandyMachineV2ProgramAddress } from '../helpers/accounts';
 
 const SIGNING_INTERVAL = 60 * 1000; //60s
 
@@ -71,9 +68,7 @@ export async function updateMetadataFromCache(
   );
   candyMachineAddress = candyMachineAddr.toBase58();
   const metadataByCandyMachine = await getAccountsByCreatorAddress(
-    (
-      await getCandyMachineCreator(new PublicKey(candyMachineAddress))
-    )[0].toBase58(),
+    candyMachineAddress,
     connection,
   );
   const differences = {};


### PR DESCRIPTION
reverting to working commit from this PR  #1527

it has been broken here : https://github.com/metaplex-foundation/metaplex/commit/e5e3121854e54d344759137f1f68e132f2bc47f0

when code to derive 1st creator from already derived 1st creator has been added -due to that the snapshot of minted NFTs always returned empty array.