### PR TITLE
Adding ImageLink in cacheContent

### DIFF
--- a/js/packages/cli/src/commands/upload.ts
+++ b/js/packages/cli/src/commands/upload.ts
@@ -359,6 +359,7 @@ export async function uploadV2({
               log.debug('Updating cache for ', asset.index);
               cacheContent.items[asset.index] = {
                 link,
+                imageLink
                 name: manifest.name,
                 onChain: false,
               };

--- a/js/packages/cli/src/commands/upload.ts
+++ b/js/packages/cli/src/commands/upload.ts
@@ -359,7 +359,7 @@ export async function uploadV2({
               log.debug('Updating cache for ', asset.index);
               cacheContent.items[asset.index] = {
                 link,
-                imageLink
+                imageLink,
                 name: manifest.name,
                 onChain: false,
               };


### PR DESCRIPTION
V2upload function was not writing the `ImageLink` field inside the cache file.
It solves the issue #1975.