### PR TITLE
Pre-calculate bundlr funding for arweave-sol

### DIFF
--- a/js/packages/cli/src/commands/upload.ts
+++ b/js/packages/cli/src/commands/upload.ts
@@ -241,9 +241,8 @@ export async function uploadV2({
 
       // Loop over every uploaded bundle of asset filepairs (PNG + JSON)
       // and save the results to the Cache object, persist it to the Cache file.
-      for (const value of arweaveBundleUploadGenerator) {
-        const { cacheKeys, arweavePathManifestLinks, updatedManifests } =
-          await value;
+      for await (const value of arweaveBundleUploadGenerator) {
+        const { cacheKeys, arweavePathManifestLinks, updatedManifests } = value;
 
         updateCacheAfterUpload(
           cacheContent,
@@ -706,9 +705,8 @@ export async function upload({
 
       // Loop over every uploaded bundle of asset filepairs (PNG + JSON)
       // and save the results to the Cache object, persist it to the Cache file.
-      for (const value of arweaveBundleUploadGenerator) {
-        const { cacheKeys, arweavePathManifestLinks, updatedManifests } =
-          await value;
+      for await (const value of arweaveBundleUploadGenerator) {
+        const { cacheKeys, arweavePathManifestLinks, updatedManifests } = value;
 
         updateCacheAfterUpload(
           cache,

--- a/js/packages/cli/src/commands/upload.ts
+++ b/js/packages/cli/src/commands/upload.ts
@@ -239,23 +239,21 @@ export async function uploadV2({
         rpcUrl,
       );
 
-      let result = arweaveBundleUploadGenerator.next();
       // Loop over every uploaded bundle of asset filepairs (PNG + JSON)
       // and save the results to the Cache object, persist it to the Cache file.
-      while (!result.done) {
+      for (const value of arweaveBundleUploadGenerator) {
         const { cacheKeys, arweavePathManifestLinks, updatedManifests } =
-          await result.value;
+          await value;
 
         updateCacheAfterUpload(
           cacheContent,
           cacheKeys,
           arweavePathManifestLinks,
-          updatedManifests,
+          updatedManifests.map(m => m.name),
         );
 
         saveCache(cacheName, env, cacheContent);
         log.info('Saved bundle upload result to cache.');
-        result = arweaveBundleUploadGenerator.next();
       }
       log.info('Upload done. Cleaning up...');
       if (storage === StorageType.ArweaveSol && env !== 'devnet') {
@@ -612,12 +610,12 @@ function updateCacheAfterUpload(
   cache: Cache,
   cacheKeys: Array<keyof Cache['items']>,
   links: string[],
-  manifests: Manifest[],
+  names: string[],
 ) {
   cacheKeys.forEach((cacheKey, idx) => {
     cache.items[cacheKey] = {
       link: links[idx],
-      name: manifests[idx].name,
+      name: names[idx],
       onChain: false,
     };
   });
@@ -706,21 +704,20 @@ export async function upload({
         batchSize,
       );
 
-      let result = arweaveBundleUploadGenerator.next();
       // Loop over every uploaded bundle of asset filepairs (PNG + JSON)
       // and save the results to the Cache object, persist it to the Cache file.
-      while (!result.done) {
+      for (const value of arweaveBundleUploadGenerator) {
         const { cacheKeys, arweavePathManifestLinks, updatedManifests } =
-          await result.value;
+          await value;
+
         updateCacheAfterUpload(
           cache,
           cacheKeys,
           arweavePathManifestLinks,
-          updatedManifests,
+          updatedManifests.map(m => m.name),
         );
         saveCache(cacheName, env, cache);
         log.info('Saved bundle upload result to cache.');
-        result = arweaveBundleUploadGenerator.next();
       }
       log.info('Upload done.');
     } else {

--- a/js/packages/cli/src/helpers/upload/arweave-bundle.ts
+++ b/js/packages/cli/src/helpers/upload/arweave-bundle.ts
@@ -64,6 +64,7 @@ type ProcessFileArgs = {
  * Represented here in its minimal form.
  */
 type Manifest = {
+  name: string;
   image: string;
   animation_url: string;
   properties: {
@@ -517,14 +518,6 @@ export function* makeArweaveBundleUploadGenerator(
           : undefined,
       manifest: manifestPath,
     };
-  });
-
-  // Yield an empty result object before processing file pairs
-  // & uploading bundles for initialization.
-  yield Promise.resolve({
-    cacheKeys: [],
-    arweavePathManifestLinks: [],
-    updatedManifests: [],
   });
 
   // As long as we still have file pairs needing upload, compute the next range

--- a/js/packages/cli/src/helpers/upload/arweave-bundle.ts
+++ b/js/packages/cli/src/helpers/upload/arweave-bundle.ts
@@ -218,7 +218,8 @@ async function getFilePairSize({
       return acc;
     } else {
       const { size } = await stat(file);
-      return acc + size;
+      //Adds the 2kb buffer for the txn header and the 10kb min file upload size for bundlr
+      return acc + 2000 + Math.max(10000, size);
     }
   }, Promise.resolve(dummyAreaveManifestByteSize));
 }
@@ -560,7 +561,7 @@ export async function* makeArweaveBundleUploadGenerator(
   while (filePairs.length) {
     const { count, size } = await getBundleRange(
       filePairs,
-      storage === StorageType.ArweaveSol ? true : false,
+      storage === StorageType.ArweaveSol,
     );
 
     log.info(


### PR DESCRIPTION
Instead of re-funding every bundle, calculate the total amount up front. This greatly speeds up the upload process.

The current calculation overestimates the amount of SOL required (1.5x) but that could be tuned if necessary.