### PR TITLE
Fix too large transaction when using SPL token for mint

### DIFF
--- a/js/packages/candy-machine-ui/src/candy-machine.ts
+++ b/js/packages/candy-machine-ui/src/candy-machine.ts
@@ -533,7 +533,7 @@ export const mintOneToken = async (
   const txnEstimate =
     892 +
     (collectionPDAAccount && state.retainAuthority ? 182 : 0) +
-    (state.tokenMint ? 145 : 0) +
+    (state.tokenMint ? 177 : 0) +
     (state.whitelistMintSettings ? 33 : 0) +
     (state.whitelistMintSettings?.mode?.burnEveryTime ? 145 : 0) +
     (state.gatekeeper ? 33 : 0) +

--- a/js/packages/cli/src/commands/mint.ts
+++ b/js/packages/cli/src/commands/mint.ts
@@ -393,7 +393,7 @@ export async function mintV2(
   const txnEstimate =
     892 +
     (collectionPDAAccount && data.retainAuthority ? 182 : 0) +
-    (candyMachine.tokenMint ? 145 : 0) +
+    (candyMachine.tokenMint ? 177 : 0) +
     (data.whitelistMintSettings ? 33 : 0) +
     (data.whitelistMintSettings?.mode?.burnEveryTime ? 145 : 0) +
     (data.gatekeeper ? 33 : 0) +


### PR DESCRIPTION
Continuation of https://github.com/metaplex-foundation/metaplex/pull/1985

Looks like the issue still persist when CM is configured with SPL token as payment. The underestimation is 32 which I have added to the tokenMint value.

CC @stegaBOB 