### PR TITLE
use new nftstorage.link gateway for nft.storage uploads

### DIFF
--- a/js/packages/cli/src/helpers/upload/nft-storage.ts
+++ b/js/packages/cli/src/helpers/upload/nft-storage.ts
@@ -30,7 +30,7 @@ export async function nftStorageUpload(
       log.info(`Media Upload ${media}`);
       // @ts-ignore - the Blob type expects a web ReadableStream, but also works with node Streams.
       const cid = await client.storeBlob({ stream: () => readStream });
-      return `https://${cid}.ipfs.dweb.link`;
+      return `https://${cid}.ipfs.nftstorage.link`;
     } catch (err) {
       log.debug(err);
       throw new Error(`Media upload error: ${err}`);
@@ -42,7 +42,7 @@ export async function nftStorageUpload(
       log.info('Upload metadata');
       const metaData = Buffer.from(JSON.stringify(manifestJson));
       const cid = await client.storeBlob(new Blob([metaData]));
-      const link = `https://${cid}.ipfs.dweb.link`;
+      const link = `https://${cid}.ipfs.nftstorage.link`;
       log.info('Upload end');
       if (animationUrl) {
         log.debug([link, imageUrl, animationUrl]);


### PR DESCRIPTION
This just updates the gateway URL used when uploading data to NFT.Storage. We've recently added a new [caching gateway](https://nft.storage/docs/concepts/gateways/#the-nftstorage-gateway) that offers much improved performance for cached content, and our latest metrics are showing cache hit rates of > 70%.

Ideally we'd not be putting gateway URLs into NFT metadata at all and relying on client-side logic to transform `ipfs://` uris, but I believe there's some more work to be done on the presentation side for that to work out. In the meantime, using the `nftstorage.link` gateway should improve read performance for any new NFTs minted using this integration.
