### PR TITLE
Increase default timeout

### DIFF
--- a/js/packages/candy-machine-ui/src/connection.tsx
+++ b/js/packages/candy-machine-ui/src/connection.tsx
@@ -346,7 +346,7 @@ export const getUnixTs = () => {
   return new Date().getTime() / 1000;
 };
 
-const DEFAULT_TIMEOUT = 15000;
+const DEFAULT_TIMEOUT = 30000;
 
 export async function sendSignedTransaction({
   signedTransaction,

--- a/js/packages/cli/src/helpers/constants.ts
+++ b/js/packages/cli/src/helpers/constants.ts
@@ -100,7 +100,7 @@ export const CONFIG_LINE_SIZE = 4 + 32 + 4 + 200;
 
 export const CACHE_PATH = './.cache';
 
-export const DEFAULT_TIMEOUT = 15000;
+export const DEFAULT_TIMEOUT = 30000;
 
 export const EXTENSION_PNG = '.png';
 export const EXTENSION_JPG = '.jpg';

--- a/js/packages/common/src/contexts/connection.tsx
+++ b/js/packages/common/src/contexts/connection.tsx
@@ -656,7 +656,7 @@ export const getUnixTs = () => {
   return new Date().getTime() / 1000;
 };
 
-const DEFAULT_TIMEOUT = 15000;
+const DEFAULT_TIMEOUT = 30000;
 
 export async function sendSignedTransaction({
   signedTransaction,

--- a/js/packages/token-entangler/src/utils/transactions.ts
+++ b/js/packages/token-entangler/src/utils/transactions.ts
@@ -18,7 +18,7 @@ interface BlockhashAndFeeCalculator {
   feeCalculator: FeeCalculator;
 }
 
-export const DEFAULT_TIMEOUT = 15000;
+export const DEFAULT_TIMEOUT = 30000;
 
 export const getUnixTs = () => {
   return new Date().getTime() / 1000;


### PR DESCRIPTION
Requests are timing out too often lately, especially on the creation of CM, this change will increase the default timeout which should hopefully increase the rate of successfully resolved requests. In the worse case scenario this will just make the process a bit  slower which should not affect anything much