### PR TITLE
Update the description of --new-cache option

### DIFF
--- a/js/packages/cli/src/candy-machine-v2-cli.ts
+++ b/js/packages/cli/src/candy-machine-v2-cli.ts
@@ -1068,7 +1068,7 @@ programCommand('sign_all')
 
 programCommand('update_existing_nfts_from_latest_cache_file')
   .option('-b, --batch-size <string>', 'Batch size', '2')
-  .option('-nc, --new-cache <string>', 'Path to new updated cache file')
+  .option('-nc, --new-cache <string>', 'New cache file name')
   .option('-d, --daemon', 'Run updating continuously', false)
   .option(
     '-r, --rpc-url <string>',


### PR DESCRIPTION
There are multiple users reports in the issue #1967 .  Users set the absolute file path instead of the file name at ``-nc`` /  ``--new-cache`` option. Currently, the description of ``-nc`` says "Path to new updated cache file", but passing the path at ``-nc`` would not work. To avoid the confusion, this PR will update the description of ``-nc`` option.  For the detail of the issue, please see my analysis: https://github.com/metaplex-foundation/metaplex/issues/1967#issuecomment-1086958759

Fixes #1967 

