### PR TITLE
Update metadata's properties.file.uri when uploading via arweave-sol

### DIFF
--- a/js/packages/cli/src/helpers/upload/arweave-bundle.ts
+++ b/js/packages/cli/src/helpers/upload/arweave-bundle.ts
@@ -325,7 +325,11 @@ async function getUpdatedManifest(
   const manifest: Manifest = JSON.parse(
     (await readFile(manifestPath)).toString(),
   );
+  const originalImage = manifest.image;
   manifest.image = imageLink;
+  manifest.properties.files.forEach(file => {
+    if (file.uri === originalImage) file.uri = imageLink;
+  });
   if (animationLink) {
     manifest.animation_url = animationLink;
   }


### PR DESCRIPTION
This should solve #2013.

Given original metadata (ie `0.json`) like:
```json
{
  "name": "name",
  "symbol": "",
  "description": "desc",
  "image": "image.png",
  "properties": {
    "files": [{ "uri": "image.png", "type": "image/png" }]
  }
}
```
this function used to produce an updated metadata with the arweave image link in the `image` property but would leave the one in `properties.files` intact:
```json
{
  "name": "name",
  "symbol": "",
  "description": "desc",
  "image": "https://arweave.net/foobarbaz?ext=png",
  "properties": {
    "files": [{ "uri": "image.png", "type": "image/png" }]
  }
}
```
but with this change it produces:
```json
{
  "name": "name",
  "symbol": "",
  "description": "desc",
  "image": "https://arweave.net/foobarbaz?ext=png",
  "properties": {
    "files": [{ "uri": "https://arweave.net/foobarbaz?ext=png", "type": "image/png" }]
  }
}
```