### PR TITLE
add bundled uploads to nft.storage uploader

### DIFF
--- a/js/packages/cli/package.json
+++ b/js/packages/cli/package.json
@@ -38,7 +38,7 @@
     "@aws-sdk/client-s3": "^3.36.0",
     "@bundlr-network/client": "^0.5.18",
     "@metaplex/arweave-cost": "^1.0.4",
-    "@nftstorage/metaplex-auth": "^1.1.0",
+    "@nftstorage/metaplex-auth": "^1.2.0",
     "@project-serum/anchor": "^0.17.0",
     "@solana/spl-token": "^0.1.8",
     "@solana/web3.js": "1.33.0",

--- a/js/packages/cli/src/candy-machine-v2-cli.ts
+++ b/js/packages/cli/src/candy-machine-v2-cli.ts
@@ -135,6 +135,7 @@ programCommand('upload')
     const {
       storage,
       nftStorageKey,
+      nftStorageGateway,
       ipfsInfuraProjectId,
       number,
       ipfsInfuraSecret,
@@ -276,6 +277,7 @@ programCommand('upload')
         retainAuthority,
         mutable,
         nftStorageKey,
+        nftStorageGateway,
         ipfsCredentials,
         pinataJwt,
         pinataGateway,

--- a/js/packages/cli/src/helpers/upload/nft-storage.ts
+++ b/js/packages/cli/src/helpers/upload/nft-storage.ts
@@ -1,77 +1,147 @@
 import log from 'loglevel';
-import fs from 'fs';
+// import fs from 'fs';
 import path from 'path';
-import { NFTStorageMetaplexor } from '@nftstorage/metaplex-auth';
-import { NFTStorage, Blob } from 'nft.storage';
+import { NFTStorageMetaplexor, NFTBundle } from '@nftstorage/metaplex-auth';
+import { NFTStorage } from 'nft.storage';
 import { Keypair } from '@solana/web3.js';
-import { setImageUrlManifest } from './file-uri';
+import * as cliProgress from 'cli-progress';
+import { AssetKey } from '../../types';
 
-export async function nftStorageUpload(
-  image: string,
-  animation: string,
-  manifestBuffer: Buffer,
-  walletKeyPair: Keypair,
-  env: string,
-  nftStorageKey: string | null,
-) {
-  // If we have an API token, use the default NFTStorage client.
-  // Otherwise, use NFTStorageMetaplexor, which uses a signature
-  // from the wallet key to authenticate.
-  // See https://github.com/nftstorage/metaplex-auth for details.
-  const client = nftStorageKey
-    ? new NFTStorage({ token: nftStorageKey })
-    : NFTStorageMetaplexor.withSecretKey(walletKeyPair.secretKey, {
-        solanaCluster: env,
-        mintingAgent: 'metaplex/candy-machine-v2-cli',
+/**
+ * The Manifest object for a given asset.
+ * This object holds the contents of the asset's JSON file.
+ * Represented here in its minimal form.
+ */
+type Manifest = {
+  name: string;
+  image: string;
+  animation_url: string;
+  properties: {
+    files: Array<{ type: string; uri: string }>;
+  };
+};
+
+export type NftStorageBundledAsset = {
+  cacheKey: string;
+  metadataJsonLink: string;
+  updatedManifest: Manifest;
+};
+
+export type NftStorageBundleUploadResult = {
+  assets: NftStorageBundledAsset[];
+};
+
+export async function* nftStorageUploadGenerator({
+  dirname,
+  assets,
+  env,
+  walletKeyPair,
+  nftStorageKey,
+  nftStorageGateway,
+  batchSize,
+}: {
+  dirname: string;
+  assets: AssetKey[];
+  env: string;
+  walletKeyPair: Keypair;
+  nftStorageKey?: string | null;
+  nftStorageGateway?: string | null;
+  batchSize?: number | null;
+}): AsyncGenerator<NftStorageBundleUploadResult> {
+  // split asset keys into batches, each of which will be bundled into a CAR file and uploaded separately
+  // default to 50 NFTs per "batch" if no batchSize is given.
+  // larger batches require fewer signatures and will be slightly faster overall if everything is sucessful,
+  // but smaller batches will take less time to retry if there's an error during upload.
+  batchSize = batchSize || 50;
+  batchSize = Math.min(batchSize, NFTBundle.MAX_ENTRIES);
+
+  const numBatches = Math.ceil(assets.length / batchSize);
+  const batches: AssetKey[][] = new Array(numBatches)
+    .fill([])
+    .map((_, i) => assets.slice(i * batchSize, (i + 1) * batchSize));
+
+  log.info(`Uploading to nft.storage in ${batches.length} batches`);
+
+  // upload the CAR file for a single bundle to nft.storage
+  const uploadCar = async (cid, car, onStoredChunk) => {
+    if (nftStorageKey) {
+      const client = new NFTStorage({ token: nftStorageKey });
+      return client.storeCar(car, { onStoredChunk });
+    } else {
+      const client = await NFTStorageMetaplexor.withSecretKey(
+        walletKeyPair.secretKey,
+        {
+          solanaCluster: env,
+          mintingAgent: 'metaplex/candy-machine-v2-cli',
+        },
+      );
+      return client.storeCar(cid, car, { onStoredChunk });
+    }
+  };
+
+  for (let i = 0; i < batches.length; i++) {
+    const batch = batches[i];
+    const batchNum = i + 1;
+    const bundle = new NFTBundle();
+    const bundled: NftStorageBundledAsset[] = [];
+
+    log.debug(`Generating bundle #${batchNum} of ${batches.length}`);
+    const packProgressBar = new cliProgress.SingleBar(
+      {
+        format: `Generating bundle #${batchNum}: [{bar}] {percentage}% | {value}/{total}`,
+      },
+      cliProgress.Presets.shades_classic,
+    );
+    packProgressBar.start(batch.length, 0);
+    for (const asset of batch) {
+      const manifestPath = path.join(dirname, `${asset.index}.json`);
+      const imagePath = path.join(dirname, asset.index + asset.mediaExt);
+      // if animation_url is set to a filepath, that will be picked up by
+      // bundle.addNFTFromFileSystem below.
+
+      log.debug(
+        `Adding NFT ${asset.index} to bundle #${batchNum} from ${manifestPath}`,
+      );
+
+      const nft = await bundle.addNFTFromFileSystem(manifestPath, imagePath, {
+        id: asset.index,
+        gatewayHost: nftStorageGateway,
       });
 
-  async function uploadMedia(media) {
-    try {
-      const readStream = fs.createReadStream(media);
-      log.info(`Media Upload ${media}`);
-      // @ts-ignore - the Blob type expects a web ReadableStream, but also works with node Streams.
-      const cid = await client.storeBlob({ stream: () => readStream });
-      return `https://${cid}.ipfs.nftstorage.link`;
-    } catch (err) {
-      log.debug(err);
-      throw new Error(`Media upload error: ${err}`);
+      bundled.push({
+        cacheKey: asset.index,
+        metadataJsonLink: nft.metadataGatewayURL,
+        updatedManifest: nft.metadata as unknown as Manifest,
+      });
+      packProgressBar.update(bundled.length);
     }
+    packProgressBar.stop();
+
+    const { car, cid } = await bundle.asCAR();
+    const totalSize = await bundle.getRawSize();
+
+    const uploadProgressBar = new cliProgress.SingleBar(
+      {
+        format: `Uploading bundle #${batchNum}: [{bar}] {percentage}%`,
+      },
+      cliProgress.Presets.shades_classic,
+    );
+
+    let stored = 0;
+    uploadProgressBar.start(totalSize, stored);
+    const onStoredChunk = (size: number) => {
+      stored += size;
+      uploadProgressBar.update(stored);
+    };
+    const bundleCID = await uploadCar(cid, car, onStoredChunk);
+
+    uploadProgressBar.stop();
+    log.info(
+      `Completed upload for bundle #${batchNum} of ${batches.length}. Bundle root CID: ${bundleCID}`,
+    );
+
+    yield {
+      assets: bundled,
+    };
   }
-
-  async function uploadMetadata(manifestJson, imageUrl, animationUrl) {
-    try {
-      log.info('Upload metadata');
-      const metaData = Buffer.from(JSON.stringify(manifestJson));
-      const cid = await client.storeBlob(new Blob([metaData]));
-      const link = `https://${cid}.ipfs.nftstorage.link`;
-      log.info('Upload end');
-      if (animationUrl) {
-        log.debug([link, imageUrl, animationUrl]);
-      } else {
-        log.debug([link, imageUrl]);
-      }
-      return [link, imageUrl, animationUrl];
-    } catch (err) {
-      log.debug(err);
-      throw new Error(`Metadata upload error: ${err}`);
-    }
-  }
-
-  // Copied from ipfsUpload
-  const imageUrl = `${await uploadMedia(image)}?ext=${path
-    .extname(image)
-    .replace('.', '')}`;
-  const animationUrl = animation
-    ? `${await uploadMedia(animation)}?ext=${path
-        .extname(animation)
-        .replace('.', '')}`
-    : undefined;
-
-  const manifestJson = await setImageUrlManifest(
-    manifestBuffer.toString('utf8'),
-    imageUrl,
-    animationUrl,
-  );
-
-  return uploadMetadata(manifestJson, imageUrl, animationUrl);
 }

--- a/js/packages/cli/src/helpers/various.ts
+++ b/js/packages/cli/src/helpers/various.ts
@@ -25,7 +25,8 @@ export async function getCandyMachineV2Config(
   configPath: any,
 ): Promise<{
   storage: StorageType;
-  nftStorageKey: string;
+  nftStorageKey: string | null;
+  nftStorageGateway: string | null;
   ipfsInfuraProjectId: string;
   number: number;
   ipfsInfuraSecret: string;
@@ -69,6 +70,7 @@ export async function getCandyMachineV2Config(
   const {
     storage,
     nftStorageKey,
+    nftStorageGateway,
     ipfsInfuraProjectId,
     number,
     ipfsInfuraSecret,
@@ -200,6 +202,7 @@ export async function getCandyMachineV2Config(
   return {
     storage,
     nftStorageKey,
+    nftStorageGateway,
     ipfsInfuraProjectId,
     number,
     ipfsInfuraSecret,

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -2597,7 +2597,7 @@
     cborg "^1.6.0"
     multiformats "^9.5.4"
 
-"@ipld/dag-pb@^2.0.2", "@ipld/dag-pb@^2.1.3":
+"@ipld/dag-pb@^2.0.2", "@ipld/dag-pb@^2.1.16", "@ipld/dag-pb@^2.1.3":
   version "2.1.16"
   resolved "https://registry.yarnpkg.com/@ipld/dag-pb/-/dag-pb-2.1.16.tgz#7133fec4f1bbce8fedb859bc2d477a0a2401de93"
   integrity sha512-5+A87ZsKZ2yEEjtW6LIzTgDJcm6O24d0lmXlubwtMblI5ZB+aTw7PH6kjc8fM6pbnNtVg4Y+c+WZ3zCxdesIBg==
@@ -3873,17 +3873,20 @@
   resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-11.1.4.tgz#370c310ba197e799235492bf71084d3acbbb2c6a"
   integrity sha512-7MPXYWsCo5qGZXyyJwBLvQkYi0hKARtpjGxjt/mdxn7A7O+jKJgAuxgOo/lnZIiXfbJzxRnSD8k6WkUwN0IVmg==
 
-"@nftstorage/metaplex-auth@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@nftstorage/metaplex-auth/-/metaplex-auth-1.1.0.tgz#67c4a3503a217ecce5e657de38ea402bbd21267d"
-  integrity sha512-99NYV76vSDmmRF+aAdAdxElmcs9yHCfdf5mjqnxI1ONlzehcTaRtD6VQ5ro7qGlXNVlzru0wK1kxIAuzn17NqQ==
+"@nftstorage/metaplex-auth@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@nftstorage/metaplex-auth/-/metaplex-auth-1.2.0.tgz#e0bb756973ced690eb88223a15c3f9bc80c1ebe1"
+  integrity sha512-ffT/cZv1GWXDVrwzNUGGxApDwQJSxUZJAqnPpTk5VBc55T2RtUm2yZ11p74h2fyam1erJH38zg7S9IoaTxSZ8w==
   dependencies:
     "@dashkite/tweetnacl" "^1.0.3"
+    "@ipld/dag-pb" "^2.1.16"
     "@solana/web3.js" "^1.30.2"
     "@web-std/fetch" "^2.1.2"
     "@web-std/file" "^1.1.4"
     ajv "^8.8.1"
     files-from-path "^0.2.1"
+    ipfs-car "^0.6.2"
+    ipfs-unixfs "^6.0.6"
     multiformats "^9.6.2"
     nft.storage "^5.2.5"
     p-retry "^5.0.0"


### PR DESCRIPTION
This replaces the nft.storage uploader with one that supports "bundles" of multiple NFTs. This greatly improves performance by avoiding rate limits and requiring fewer signatures to authorize uploads.

See https://github.com/nftstorage/metaplex-auth/pull/39 for context.

The existing `batchSize` config param is used to determine how many NFTs to include in each bundle, with a default of 50 if no `batchSize` is set, and a maximum of NFTBundle.MAX_ENTRIES (currently 2200).

This PR also adds an `nftStorageGateway` config option that can override the default HTTP gateway host of `https://nftstorage.link` used in metadata links, in case the creator has a preferred gateway.

Finally, the `files` array of the final metadata now contains two entries for each asset file. The first entry, with `cdn = true` is an HTTP gateway link, while the second, with `cdn = false` is an `ipfs://` URI that can be used to locate the data using any IPFS peer or gateway. This should add a bit of resiliency in case the primary gateway should go down, although that will require clients that know to look for the alternative `ipfs://` URIs.

So far I've tested this with a collection of 500 nfts, each with an image of a few KB. This branch completed the upload in about 12 minutes, with the default batch size of 50 (so 10 bundles total). The code currently in `master` took almost 40 minutes to complete the upload, and a few NFTs failed due to rate limit errors. 

@stegaBOB if you have any time to review or know someone who does, that would be sweet 😄 Also, please let me know if you have any questions.