### PR TITLE
Fix token entangler swap CLI command

### DIFF
--- a/js/packages/cli/src/token-entangler-cli.ts
+++ b/js/packages/cli/src/token-entangler-cli.ts
@@ -332,6 +332,7 @@ programCommand('swap')
         transferAuthority: transferAuthority.publicKey,
         paymentTransferAuthority: paymentTransferAuthority.publicKey,
         token,
+        tokenMint,
         replacementTokenMetadata,
         replacementToken,
         replacementTokenMint,


### PR DESCRIPTION
Add `tokenMint` to list of instruction accounts passed to CLI.