### PR TITLE
fix: incorrect condition while checking spl token account config

### DIFF
--- a/js/packages/cli/src/helpers/various.ts
+++ b/js/packages/cli/src/helpers/various.ts
@@ -104,7 +104,7 @@ export async function getCandyMachineV2Config(
         )
       )[0]
     : null;
-  if (splToken) {
+  if (splTokenAccount) {
     if (solTreasuryAccount) {
       throw new Error(
         'If spl-token-account or spl-token is set then sol-treasury-account cannot be set',


### PR DESCRIPTION
Fix incorrect condition while checking SPL token account config