### PR TITLE
adding Djib Storage

### DIFF
--- a/js/packages/cli/src/commands/upload.ts
+++ b/js/packages/cli/src/commands/upload.ts
@@ -21,6 +21,7 @@ import {
 } from '../helpers/upload/arweave-bundle';
 import { awsUpload } from '../helpers/upload/aws';
 import { ipfsCreds, ipfsUpload } from '../helpers/upload/ipfs';
+import { djibUpload } from '../helpers/upload/djib';
 
 import { StorageType } from '../helpers/storage-type';
 import { AssetKey } from '../types';
@@ -336,6 +337,17 @@ export async function uploadV2({
                   image,
                   animation,
                   manifestBuffer,
+                );
+                break;
+              case StorageType.Djib:
+                [link, imageLink, animationLink] = await djibUpload(
+                  asset.index,
+                  image,
+                  animation,
+                  manifestBuffer,
+                  walletKeyPair,
+                  anchorProgram,
+                  env,
                 );
                 break;
               case StorageType.Arweave:
@@ -762,6 +774,17 @@ export async function upload({
                       image,
                       animation,
                       manifestBuffer,
+                    );
+                    break;
+                  case StorageType.Djib:
+                    [link, imageLink, animationLink] = await djibUpload(
+                      assetKey.index,
+                      image,
+                      animation,
+                      manifestBuffer,
+                      walletKeyPair,
+                      anchorProgram,
+                      env,
                     );
                     break;
                   case StorageType.Arweave:

--- a/js/packages/cli/src/helpers/storage-type.ts
+++ b/js/packages/cli/src/helpers/storage-type.ts
@@ -6,4 +6,5 @@ export enum StorageType {
   Aws = 'aws',
   NftStorage = 'nft-storage',
   Pinata = 'pinata',
+  Djib = 'djib',
 }

--- a/js/packages/cli/src/helpers/upload/djib.ts
+++ b/js/packages/cli/src/helpers/upload/djib.ts
@@ -1,0 +1,106 @@
+import { Keypair } from '@solana/web3.js';
+import * as fetch from 'node-fetch';
+import * as fs from 'fs';
+import * as path from 'path';
+import FormData from 'form-data';
+import log from 'loglevel';
+
+export async function djibUpload(
+  index: string,
+  image: string,
+  animation: string,
+  manifestBuffer: Buffer,
+  walletKeyPair: Keypair,
+  anchorProgram: any,
+  network: string,
+) {
+  const djibRPC =
+    network === 'mainnet-beta'
+      ? 'https://mainrpc.djib.io'
+      : network === 'testnet'
+      ? 'https://testrpc.djib.io'
+      : 'https://devrpc.djib.io';
+
+  // upload file on djib network
+  async function uploadFile(fileBuff: any, contentType: any, filename: string) {
+    const data = new FormData();
+    data.append('publickey', walletKeyPair.publicKey.toString());
+    data.append('type', 'public');
+    data.append('files[]', fileBuff, {
+      filename: filename,
+      contentType: contentType,
+    });
+    const { link, error } = await fetch(`${djibRPC}/upload`, {
+      method: 'POST',
+      body: data,
+    })
+      .then(function (res: any) {
+        return res.json();
+      })
+      .then(function (res: any) {
+        if (res.result == undefined || res.result.length == 0)
+          return { link: '', error: `No Response (${djibRPC}/upload)` };
+        return { link: res.result[0], error: undefined };
+      })
+      .catch(function (e: any) {
+        return { link: '', error: e.toString() };
+      });
+    return {
+      link,
+      error,
+    };
+  }
+
+  // upload controller
+  async function doUpload(fileBuff: any, filename: any, contentType: any) {
+    const linkObj = await uploadFile(fileBuff, contentType, filename);
+    if (linkObj.error != undefined) return { error: linkObj.error };
+    log.debug(`Uploaded link for ${filename}: ${linkObj.link}`);
+    return { error: undefined, link: linkObj.link };
+  }
+
+  // process media file
+  async function processMedia(filePath: string) {
+    const fileExt = path.extname(filePath);
+    const fileName = `${index}${fileExt}`;
+    const fileContentType = `image/${fileExt.replace('.', '')}`;
+    return await doUpload(
+      fs.createReadStream(filePath),
+      fileName,
+      fileContentType,
+    );
+  }
+
+  // process manifest file
+  async function processJson(manifestJson: any) {
+    const strManifest = JSON.stringify(manifestJson);
+    const jsonBuff = Buffer.from(strManifest);
+    const fileName = `${index}.json`;
+    const fileContentType = `text/json`;
+    return await doUpload(jsonBuff, fileName, fileContentType);
+  }
+
+  const imageObj = await processMedia(image);
+  if (imageObj.error != undefined) {
+    log.error(imageObj.error);
+    return null;
+  }
+  const animationObj = animation ? await processMedia(animation) : undefined;
+  if (animationObj && animationObj.error != undefined) {
+    log.error(animationObj.error);
+    return null;
+  }
+  const manifestJson = JSON.parse(manifestBuffer.toString('utf8'));
+  manifestJson.image = imageObj.link;
+  if (animation) manifestJson.animation_url = animationObj.link;
+  const manifestObj = await processJson(manifestJson);
+  if (manifestObj.error != undefined) {
+    log.error(manifestObj.error);
+    return null;
+  }
+  return [
+    manifestObj.link,
+    imageObj.link,
+    animationObj ? animationObj.link : undefined,
+  ];
+}


### PR DESCRIPTION
Hi @stegaBOB, last time our pull request was denied due to the reason that you rightfully brought up. We took those points wholeheartedly and started to adopt more market on our technology; at this moment we have over 20k holders of our token and a community size of 40K, we also have backers that have backed us to provide the our services for free to NFT creators. Our IPFS nodes are production ready. Djib is not only providing IPFS integration for Metaplex users but also has advantage of being free for NFT creators and has better load time due to our global cache system. The code has been modified and ready for getting accepted. We deeply appreciate if you kindly enable Metaplex users to benefit from our free and open source technology.

In case of risk mitigation for NFT creators as an apposed to NFT storage we offer link to assets with global IPFS cluster, plus domain names are set in safe CID standard manner, this protect NFT creators whom are using our technology from incidents that happened to NFT storage a week ago.


https://twitter.com/DjibChain 
https://docs.djib.io/ 
https://djib.io/ 
