### PR TITLE
Fixed account size when hiddenSettings are used

### DIFF
--- a/js/packages/cli/src/helpers/instructions.ts
+++ b/js/packages/cli/src/helpers/instructions.ts
@@ -97,10 +97,12 @@ export async function createCandyMachineV2Account(
 ) {
   const size =
     CONFIG_ARRAY_START_V2 +
-    4 +
-    candyData.itemsAvailable.toNumber() * CONFIG_LINE_SIZE_V2 +
-    8 +
-    2 * (Math.floor(candyData.itemsAvailable.toNumber() / 8) + 1);
+    (candyData.hiddenSettings
+      ? 0
+      : 4 +
+        candyData.itemsAvailable.toNumber() * CONFIG_LINE_SIZE_V2 +
+        8 +
+        2 * (Math.floor(candyData.itemsAvailable.toNumber() / 8) + 1));
 
   return anchor.web3.SystemProgram.createAccount({
     fromPubkey: payerWallet,


### PR DESCRIPTION
Not allocating space for config lines when `hiddenSettings` are used.

This PR can only be merged after mpl_candy_machine PR 415 is deployed:
- https://github.com/metaplex-foundation/metaplex-program-library/pull/415