### PR TITLE
Fix: End Setting Type Configuration [#2095]

### DIFF
--- a/js/packages/cli/src/helpers/various.ts
+++ b/js/packages/cli/src/helpers/various.ts
@@ -178,9 +178,26 @@ export async function getCandyMachineV2Config(
   }
 
   if (endSettings) {
-    if (endSettings.endSettingType.date) {
+    const isEndSettingTypeDatePresent = Object.getOwnPropertyDescriptor(
+      endSettings.endSettingType,
+      'date',
+    );
+    const isEndSettingTypeAmountPresent = Object.getOwnPropertyDescriptor(
+      endSettings.endSettingType,
+      'amount',
+    );
+
+    const isBothEndSettingTypePresent =
+      isEndSettingTypeDatePresent && isEndSettingTypeAmountPresent;
+    if (isBothEndSettingTypePresent) {
+      throw new Error(
+        'Invalid Config: `endSettingType` must include only one property of "date" or "amount".',
+      );
+    }
+
+    if (isEndSettingTypeDatePresent) {
       endSettings.number = new BN(parseDate(endSettings.value));
-    } else if (endSettings.endSettingType.amount) {
+    } else if (isEndSettingTypeAmountPresent) {
       endSettings.number = new BN(endSettings.value);
     }
     delete endSettings.value;

--- a/js/packages/cli/src/helpers/various.ts
+++ b/js/packages/cli/src/helpers/various.ts
@@ -195,6 +195,18 @@ export async function getCandyMachineV2Config(
       );
     }
 
+    if (isEndSettingTypeDatePresent && !endSettings.endSettingType.date) {
+      throw new Error(
+        'Invalid Config: `endSettingType.date` must be `true` when present.',
+      );
+    }
+
+    if (isEndSettingTypeAmountPresent && !endSettings.endSettingType.amount) {
+      throw new Error(
+        'Invalid Config: `endSettingType.amount` must be `true` when present.',
+      );
+    }
+
     if (isEndSettingTypeDatePresent) {
       endSettings.number = new BN(parseDate(endSettings.value));
     } else if (isEndSettingTypeAmountPresent) {

--- a/js/packages/cli/src/helpers/various.ts
+++ b/js/packages/cli/src/helpers/various.ts
@@ -178,6 +178,16 @@ export async function getCandyMachineV2Config(
   }
 
   if (endSettings) {
+    const hasEndSettingType = Object.getOwnPropertyDescriptor(
+      endSettings,
+      'endSettingType',
+    );
+    if (!hasEndSettingType) {
+      throw new Error(
+        'Invalid Config: `endSettingType` must be present under `endSettings`.',
+      );
+    }
+
     const isEndSettingTypeDatePresent = Object.getOwnPropertyDescriptor(
       endSettings.endSettingType,
       'date',
@@ -187,9 +197,11 @@ export async function getCandyMachineV2Config(
       'amount',
     );
 
+    const isNoEndSettingTypePresent =
+      !isEndSettingTypeDatePresent && !isEndSettingTypeAmountPresent;
     const isBothEndSettingTypePresent =
       isEndSettingTypeDatePresent && isEndSettingTypeAmountPresent;
-    if (isBothEndSettingTypePresent) {
+    if (isBothEndSettingTypePresent || isNoEndSettingTypePresent) {
       throw new Error(
         'Invalid Config: `endSettingType` must include only one property of "date" or "amount".',
       );


### PR DESCRIPTION
See #2095 for description of bug.

When the configuration json for `endSettingType` is set as such:

```
"endSettingType": {
  "date": false,
  "amount": true
}
```

the CLI will set the Candy Machine config to use `endSettingType` as `date`. 

This PR enforces the configuration to only have one of the properties present under `endSettingType`.

**NOTE**

My first pass was to do a simple check in `getCandyMachineV2Config` and enforce that only one of the properties is present.

Thinking on it more, I believe the CLI would be best suited if `endSettingType` was not an `object` with properties but instead a `string` with value of `amount` or `date`. Currently, the `json` configuration doesn't map well to the enum in the CM rust contract. This would require a larger change along with doc updates.




resolves #2095.