### PR TITLE
Use encoded private key

### DIFF
--- a/js/packages/cli/src/candy-machine-v2-cli.ts
+++ b/js/packages/cli/src/candy-machine-v2-cli.ts
@@ -1233,7 +1233,7 @@ function programCommand(
 }
 
 programCommand('decode_private_key', { requireWallet: false })
-  .argument('<private key>', 'Base58 encoded Private key')
+  .argument('<private key>', 'Base58 encoded private key')
   .action(async privKey => {
     const decodedPrivKey = Uint8Array.from(bs58.decode(privKey));
     console.log(decodedPrivKey);

--- a/js/packages/cli/src/candy-machine-v2-cli.ts
+++ b/js/packages/cli/src/candy-machine-v2-cli.ts
@@ -47,6 +47,7 @@ import { removeCollection } from './commands/remove-collection';
 import { setCollection } from './commands/set-collection';
 import { withdrawBundlr } from './helpers/upload/arweave-bundle';
 import { CollectionData } from './types';
+import { bs58 } from '@project-serum/anchor/dist/cjs/utils/bytes';
 
 program.version('0.0.2');
 const supportedImageTypes = {
@@ -1230,6 +1231,13 @@ function programCommand(
 
   return cmProgram;
 }
+
+programCommand('create-key-array', { requireWallet: false })
+  .argument('<private key>', 'Base58 encoded Private key')
+  .action(async privKey => {
+    const decodedPrivKey = Uint8Array.from(bs58.decode(privKey));
+    console.log(decodedPrivKey);
+  });
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function setLogLevel(value, prev) {

--- a/js/packages/cli/src/candy-machine-v2-cli.ts
+++ b/js/packages/cli/src/candy-machine-v2-cli.ts
@@ -1232,7 +1232,7 @@ function programCommand(
   return cmProgram;
 }
 
-programCommand('create-key-array', { requireWallet: false })
+programCommand('decode_private_key', { requireWallet: false })
   .argument('<private key>', 'Base58 encoded Private key')
   .action(async privKey => {
     const decodedPrivKey = Uint8Array.from(bs58.decode(privKey));

--- a/js/packages/cli/src/helpers/accounts.ts
+++ b/js/packages/cli/src/helpers/accounts.ts
@@ -30,6 +30,7 @@ import { web3 } from '@project-serum/anchor';
 import log from 'loglevel';
 import { AccountLayout, u64 } from '@solana/spl-token';
 import { getCluster } from './various';
+import { bs58 } from '@project-serum/anchor/dist/cjs/utils/bytes';
 export type AccountAndPubkey = {
   pubkey: string;
   account: AccountInfo<Buffer>;
@@ -522,9 +523,14 @@ export function loadWalletKey(keypair): Keypair {
   if (!keypair || keypair == '') {
     throw new Error('Keypair is required!');
   }
-  const loaded = Keypair.fromSecretKey(
-    new Uint8Array(JSON.parse(fs.readFileSync(keypair).toString())),
+
+  const decodedKey = new Uint8Array(
+    keypair.endsWith('.json') && !Array.isArray(keypair)
+      ? JSON.parse(fs.readFileSync(keypair).toString())
+      : bs58.decode(keypair),
   );
+
+  const loaded = Keypair.fromSecretKey(decodedKey);
   log.info(`wallet public key: ${loaded.publicKey}`);
   return loaded;
 }


### PR DESCRIPTION
Added 

- Feature to allow the user to use their encoded private key (e.g. private key exported from Phantom) with the `-k` flag instead of having to specify a JSON file containing a decoded private key. 
- Subcommand `decode_private_key` to decode a private key into an array

See #2098 