### PR TITLE
Fix: End Setting Type Configuration Update (#2095)

### DIFF
--- a/js/packages/cli/src/candy-machine-v2-cli.ts
+++ b/js/packages/cli/src/candy-machine-v2-cli.ts
@@ -763,18 +763,15 @@ programCommand('show')
 
       //@ts-ignore
       log.info('hidden settings: ', machine.data.hiddenSettings);
-      if (machine.data.endSettings) {
-        log.info('End settings: ');
+      const endSettings = machine.data.endSettings;
+      if (endSettings) {
+        log.info('End settings:');
 
-        if (machine.data.endSettings.endSettingType.date) {
+        if (endSettings.endSettingType.date) {
           //@ts-ignore
-          log.info('End on', new Date(machine.data.endSettings.number * 1000));
-        } else {
-          log.info(
-            'End when',
-            machine.data.endSettings.number.toNumber(),
-            'sold',
-          );
+          log.info('\tEnd on', new Date(endSettings.number * 1000));
+        } else if (endSettings.endSettingType.amount) {
+          log.info('\tEnd when', endSettings.number.toNumber(), 'sold');
         }
       } else {
         log.info('No end settings detected');

--- a/js/packages/cli/src/helpers/various.ts
+++ b/js/packages/cli/src/helpers/various.ts
@@ -12,6 +12,7 @@ import { StorageType } from './storage-type';
 
 import { getAtaForMint } from './accounts';
 import { CLUSTERS, DEFAULT_CLUSTER } from './constants';
+import { EndSettingType } from '../types';
 import {
   Uses,
   UseMethod,
@@ -178,9 +179,31 @@ export async function getCandyMachineV2Config(
   }
 
   if (endSettings) {
-    if (endSettings.endSettingType.date) {
+    const endSettingType = endSettings.endSettingType as EndSettingType;
+    if (!endSettingType || typeof endSettingType !== 'string') {
+      throw new Error(
+        'Invalid Config: `endSettingType` must be set to a string.',
+      );
+    }
+
+    const isValidEndSettingType = [
+      EndSettingType.AMOUNT,
+      EndSettingType.DATE,
+    ].includes(endSettingType);
+
+    if (!isValidEndSettingType) {
+      throw new Error(
+        'Invalid Config: `endSettingType` must be set to "Date" or "Amount".',
+      );
+    }
+
+    // override endSettingType with `date` or `amount` as property set to true
+    // such that it serializes correctly
+    if (endSettingType === EndSettingType.DATE) {
+      endSettings.endSettingType = { date: true };
       endSettings.number = new BN(parseDate(endSettings.value));
-    } else if (endSettings.endSettingType.amount) {
+    } else if (endSettingType === EndSettingType.AMOUNT) {
+      endSettings.endSettingType = { amount: true };
       endSettings.number = new BN(endSettings.value);
     }
     delete endSettings.value;

--- a/js/packages/cli/src/types.ts
+++ b/js/packages/cli/src/types.ts
@@ -253,3 +253,8 @@ export interface CollectionData {
 }
 
 export type AssetKey = { mediaExt: string; index: string };
+
+export enum EndSettingType {
+  AMOUNT = 'Amount',
+  DATE = 'Date',
+}


### PR DESCRIPTION
change configuration to use a string for `endSettingType` instead of an object which led to possible issues.

this matches the configuration setup in the new candy machine cli, sugar.
> https://github.com/metaplex-foundation/sugar/blob/main/src/create_config/process.rs#L466

- check for valid `endSettingType` value
- throw error if endSettings present or not the correct value

this replace https://github.com/metaplex-foundation/metaplex/pull/2096.