### PR TITLE
Allow empty string symbol in asset manifest when create candy machine

### DIFF
--- a/js/packages/cli/src/commands/upload.ts
+++ b/js/packages/cli/src/commands/upload.ts
@@ -488,9 +488,9 @@ export function getAssetManifest(dirname: string, assetKey: string): Manifest {
     fs.readFileSync(manifestPath).toString(),
   );
   if (!('symbol' in manifest)) {
-    throw new Error(`Invalid asset manifest, field 'symbol' must be defined.`);
+    throw new TypeError(`Invalid asset manifest, field 'symbol' must be defined.`);
   } else if (typeof manifest.symbol !== 'string') {
-    throw new Error(`Invalid asset manifest, field 'symbol' must be a string.`);
+    throw new TypeError(`Invalid asset manifest, field 'symbol' must be a string.`);
   }
   manifest.image = manifest.image.replace('image', assetIndex);
 

--- a/js/packages/cli/src/commands/upload.ts
+++ b/js/packages/cli/src/commands/upload.ts
@@ -487,6 +487,11 @@ export function getAssetManifest(dirname: string, assetKey: string): Manifest {
   const manifest: Manifest = JSON.parse(
     fs.readFileSync(manifestPath).toString(),
   );
+  if (!('symbol' in manifest)) {
+    throw new Error(`Invalid asset manifest, field 'symbol' must be defined.`);
+  } else if (typeof manifest.symbol !== 'string') {
+    throw new Error(`Invalid asset manifest, field 'symbol' must be a string.`);
+  }
   manifest.image = manifest.image.replace('image', assetIndex);
 
   if ('animation_url' in manifest) {

--- a/js/packages/cli/src/commands/upload.ts
+++ b/js/packages/cli/src/commands/upload.ts
@@ -488,9 +488,13 @@ export function getAssetManifest(dirname: string, assetKey: string): Manifest {
     fs.readFileSync(manifestPath).toString(),
   );
   if (!('symbol' in manifest)) {
-    throw new TypeError(`Invalid asset manifest, field 'symbol' must be defined.`);
+    throw new TypeError(
+      `Invalid asset manifest, field 'symbol' must be defined.`,
+    );
   } else if (typeof manifest.symbol !== 'string') {
-    throw new TypeError(`Invalid asset manifest, field 'symbol' must be a string.`);
+    throw new TypeError(
+      `Invalid asset manifest, field 'symbol' must be a string.`,
+    );
   }
   manifest.image = manifest.image.replace('image', assetIndex);
 

--- a/js/packages/cli/src/commands/upload.ts
+++ b/js/packages/cli/src/commands/upload.ts
@@ -487,10 +487,8 @@ export function getAssetManifest(dirname: string, assetKey: string): Manifest {
   const manifest: Manifest = JSON.parse(
     fs.readFileSync(manifestPath).toString(),
   );
-  if (!('symbol' in manifest)) {
-    throw new TypeError(
-      `Invalid asset manifest, field 'symbol' must be defined.`,
-    );
+  if (manifest.symbol === undefined) {
+    manifest.symbol = '';
   } else if (typeof manifest.symbol !== 'string') {
     throw new TypeError(
       `Invalid asset manifest, field 'symbol' must be a string.`,

--- a/js/packages/cli/src/helpers/accounts.ts
+++ b/js/packages/cli/src/helpers/accounts.ts
@@ -125,10 +125,6 @@ export const createCandyMachineV2 = async function (
   const candyAccount = Keypair.generate();
   candyData.uuid = uuidFromConfigPubkey(candyAccount.publicKey);
 
-  if (!candyData.symbol) {
-    throw new Error(`Invalid config, there must be a symbol.`);
-  }
-
   if (!candyData.creators || candyData.creators.length === 0) {
     throw new Error(`Invalid config, there must be at least one creator.`);
   }


### PR DESCRIPTION
PR #1693 break the CLI when trying to create candy machine with empty string symbol. This PR is fixing the issue by:
1. Move the validation to earlier phase, when reading the asset manifest
2. Ensure symbol is defined and is a string
