### PR TITLE
Set and verify collection

### DIFF
--- a/js/packages/cli/src/cli-nft.ts
+++ b/js/packages/cli/src/cli-nft.ts
@@ -5,6 +5,7 @@ import {
   createMetadataAccount,
   mintNFT,
   setAndVerifyCollection,
+  setAndVerifyCollectionAll,
   updateMetadata,
   validateMetadata,
   verifyCollection,
@@ -206,6 +207,38 @@ programCommand('set-and-verify-collection')
       solConnection,
       walletKeyPair,
       collectionMintKey,
+    );
+  });
+
+programCommand('set-and-verify-collection-all')
+  .requiredOption('-h, --hashlist <path>', 'hashlist for the collection')
+  .requiredOption(
+    '-c, --collection-mint <string>',
+    'base58 mint key: A collection is an NFT that can be verified as the collection for this nft',
+  )
+  .option(
+    '-r, --rpc-url <string>',
+    'custom rpc url since this is a heavy command',
+  )
+  .option(
+    '-rl, --rate-limit <number>',
+    'max number of concurrent requests for the write indices command',
+  )
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  .action(async (directory, cmd) => {
+    const { keypair, env, hashlist, collectionMint, rpcUrl, rateLimit } =
+      cmd.opts();
+    const collectionMintKey = new PublicKey(collectionMint);
+    const solConnection = new web3.Connection(rpcUrl || getCluster(env));
+    const walletKeyPair = loadWalletKey(keypair);
+
+    const mintList: string[] = JSON.parse(fs.readFileSync(hashlist, 'utf-8'));
+    await setAndVerifyCollectionAll(
+      mintList,
+      solConnection,
+      walletKeyPair,
+      collectionMintKey,
+      rateLimit,
     );
   });
 

--- a/js/packages/cli/src/cli-nft.ts
+++ b/js/packages/cli/src/cli-nft.ts
@@ -186,8 +186,8 @@ programCommand('update-metadata')
   });
 
 programCommand('set-and-verify-collection')
-  .option('-m, --mint <string>', 'base58 mint key')
-  .option(
+  .requiredOption('-m, --mint <string>', 'base58 mint key')
+  .requiredOption(
     '-c, --collection-mint <string>',
     'base58 mint key: A collection is an NFT that can be verified as the collection for this nft',
   )

--- a/js/packages/cli/src/cli-nft.ts
+++ b/js/packages/cli/src/cli-nft.ts
@@ -4,6 +4,7 @@ import {
   createMetadata,
   createMetadataAccount,
   mintNFT,
+  setAndVerifyCollection,
   updateMetadata,
   validateMetadata,
   verifyCollection,
@@ -180,6 +181,31 @@ programCommand('update-metadata')
       collectionKey,
       verifyCreators,
       structuredUseMethod,
+    );
+  });
+
+programCommand('set-and-verify-collection')
+  .option('-m, --mint <string>', 'base58 mint key')
+  .option(
+    '-c, --collection-mint <string>',
+    'base58 mint key: A collection is an NFT that can be verified as the collection for this nft',
+  )
+  .option(
+    '-r, --rpc-url <string>',
+    'custom rpc url since this is a heavy command',
+  )
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  .action(async (directory, cmd) => {
+    const { keypair, env, mint, collectionMint, rpcUrl } = cmd.opts();
+    const mintKey = new PublicKey(mint);
+    const collectionMintKey = new PublicKey(collectionMint);
+    const solConnection = new web3.Connection(rpcUrl || getCluster(env));
+    const walletKeyPair = loadWalletKey(keypair);
+    await setAndVerifyCollection(
+      mintKey,
+      solConnection,
+      walletKeyPair,
+      collectionMintKey,
     );
   });
 


### PR DESCRIPTION
I added two commands to `cli-nft.ts` to simplify the migration process to the collection standard. Would be interesting to do the collection mint in another command, so devs can run locally with their own rpc, reducing the load in the certified collections website.