### PR TITLE
Adding check for Solana cluster env name

### DIFF
--- a/js/packages/cli/src/auction-house-cli.ts
+++ b/js/packages/cli/src/auction-house-cli.ts
@@ -1555,7 +1555,7 @@ function programCommand(name: string) {
     .command(name)
     .option(
       '-e, --env <string>',
-      'Solana cluster env name',
+      'Solana cluster env name, i.e. mainnet-beta, testnet, devnet',
       'devnet', //mainnet-beta, testnet, devnet
     )
     .option(

--- a/js/packages/cli/src/helpers/various.ts
+++ b/js/packages/cli/src/helpers/various.ts
@@ -6,6 +6,7 @@ import {
   Keypair,
 } from '@solana/web3.js';
 import fs from 'fs';
+import log from 'loglevel';
 import { BN, Program, web3 } from '@project-serum/anchor';
 import { Token, TOKEN_PROGRAM_ID } from '@solana/spl-token';
 import { StorageType } from './storage-type';
@@ -387,12 +388,20 @@ export const getPriceWithMantissa = async (
 };
 
 export function getCluster(name: string): string {
+  if (name === '') {
+    log.info('Using cluster', DEFAULT_CLUSTER.name);
+    return DEFAULT_CLUSTER.url;
+  }
+
   for (const cluster of CLUSTERS) {
     if (cluster.name === name) {
+      log.info('Using cluster', cluster.name);
       return cluster.url;
     }
   }
-  return DEFAULT_CLUSTER.url;
+
+  throw new Error(`Could not get cluster: ${name}`);
+  return null;
 }
 
 export function parseUses(useMethod: string, total: number): Uses | null {


### PR DESCRIPTION
### Notes
- Previously if the name was wrong it would default to devnet.
- With this change it will use the default if nothing is specified,
  but if something is specified and not found it will throw an
  error.

### Testing
- Ran it and observed passing behavior with default specified, a
  valid env specified, and observed the error thrown with an invalid
  env specified.

### Question
Not sure if `getCluster` should return default when empty string is passed in.  In the AH CLI it passes in 'devnet' as its a default coming from `programCommand`, but I didn't want to potentially break other use cases.