### PR TITLE
Add better error messages to withdraw command

### DIFF
--- a/js/packages/cli/src/candy-machine-v2-cli.ts
+++ b/js/packages/cli/src/candy-machine-v2-cli.ts
@@ -330,32 +330,30 @@ programCommand('withdraw')
     }
     const walletKeypair = loadWalletKey(keypair);
     const anchorProgram = await loadCandyProgramV2(walletKeypair, env, rpcUrl);
-    const configOrCommitment = {
-      commitment: 'confirmed',
-      filters: [
-        {
-          memcmp: {
-            offset: 8,
-            bytes: walletKeypair.publicKey.toBase58(),
-          },
-        },
-      ],
-    };
-    const machines: AccountAndPubkey[] = await getProgramAccounts(
-      anchorProgram.provider.connection,
-      CANDY_MACHINE_PROGRAM_V2_ID.toBase58(),
-      configOrCommitment,
-    );
-    const currentMachine = machines?.find(machine => {
-      return machine.pubkey === candyMachineId;
-    });
 
-    if (!currentMachine) {
-      log.error(`Candy Machine ${candyMachineId} not found`);
+    const candyMachineAccount =
+      await anchorProgram.provider.connection.getAccountInfo(
+        new PublicKey(candyMachineId),
+        'confirmed',
+      );
+    if (!candyMachineAccount) {
+      log.error(
+        `Candy Machine ${candyMachineId} not found on ${rpcUrl ?? env}`,
+      );
       return;
     }
 
-    const refundAmount = currentMachine.account.lamports / LAMPORTS_PER_SOL;
+    const candyMachine = await anchorProgram.account.candyMachine.fetch(
+      candyMachineId,
+    );
+    if (!candyMachine.authority.equals(walletKeypair.publicKey)) {
+      log.error(`Incorrect wallet for candy machine ${candyMachineId}`);
+      log.error(`Candy machine authority is ${candyMachine.authority}`);
+      log.error(`Keypair "${keypair}" is ${walletKeypair.publicKey}`);
+      return;
+    }
+
+    const refundAmount = candyMachineAccount.lamports / LAMPORTS_PER_SOL;
     const cpf = parseFloat(charityPercent);
     let charityPub;
     log.info(`Amount to be drained from ${candyMachineId}: ${refundAmount}`);
@@ -373,13 +371,13 @@ programCommand('withdraw')
         `WARNING: This command will drain the SOL from Candy Machine ${candyMachineId}. This will break your Candy Machine if its still in use`,
       );
       try {
-        if (currentMachine.account.lamports > 0) {
+        if (candyMachineAccount.lamports > 0) {
           const tx = await withdrawV2(
             anchorProgram,
             walletKeypair,
             env,
             new PublicKey(candyMachineId),
-            currentMachine.account.lamports,
+            candyMachineAccount.lamports,
             charityPub,
             cpf,
           );


### PR DESCRIPTION
Inform the user if they are using the wrong keypair or if the candy machine doesn't exist on that network.

Wrong keypair:
```
wallet public key: 2HFxkoiGDJbCEvduYrJkLD5X7Uwddo2FjmN3jvnWPyy8
Using cluster mainnet-beta
Incorrect wallet for candy machine Ej6MGpsqYLgpfNGcLLQksiNPYWnfvkqqTrEqyHQqWtVb
Candy machine authority is ERRERiw8k8x2pjLAmW12WfMUpw6QKT5MQvCaAD9aUPav
Keypair "id.json" is 2HFxkoiGDJbCEvduYrJkLD5X7Uwddo2FjmN3jvnWPyy8
```

Candy machine not found:
```
wallet public key: 2HFxkoiGDJbCEvduYrJkLD5X7Uwddo2FjmN3jvnWPyy8
Using cluster mainnet-beta
Candy Machine Ej6MGpsqYLgpfNGcLLQksiNPYWnfvkqqTrEqyHQqWtVb not found on mainnet-beta
```