### PR TITLE
Bugfix: Make the data an integer

### DIFF
--- a/js/packages/common/src/utils/assets.ts
+++ b/js/packages/common/src/utils/assets.ts
@@ -10,5 +10,5 @@ export async function getAssetCostToStore(files: { size: number }[]) {
   const sizes = files.map(f => f.size);
   const result = await calculate(sizes);
 
-  return LAMPORTS_PER_SOL * result.solana;
+  return Math.ceil(LAMPORTS_PER_SOL * result.solana);
 }


### PR DESCRIPTION
(LAMPORTS_PER_SOL * result.solana) May not be an integer and throw an error when convert to BN 