### PR TITLE
Support for "Init Empty Machine"

### DIFF
--- a/js/packages/cli/src/candy-machine-v2-cli.ts
+++ b/js/packages/cli/src/candy-machine-v2-cli.ts
@@ -348,8 +348,16 @@ programCommand('init_empty_machine')
     'optional flag to prevent the candy machine from using an on chain collection',
   )
   .requiredOption(
-    '--creators',
-    'e.g. --creators "{creator1Address},{creator1Verified},{creator1Share};{creator2Address},{creator2Verified},{creator2Share};...etc',
+    '--symbol <string>',
+    'Token metadata symbol. Symbol will be shared by all generated tokens.',
+  )
+  .requiredOption(
+    '--seller-fee-basis-points <string>',
+    'Token metadata symbol. Symbol will be shared by all generated tokens.',
+  )
+  .requiredOption(
+    '--creators-delimited <string>',
+    'e.g. --creators-delimited "{creator1Address},{creator1Verified},{creator1Share};{creator2Address},{creator2Verified},{creator2Share};...etc',
   )
   .action(async (args, cmd) => {
     const {
@@ -364,6 +372,8 @@ programCommand('init_empty_machine')
       creatorsDelimited
     } = cmd.opts();
 
+    log.info(creatorsDelimited)
+
 
     // e.g. --creators "{address},{verified},{share};..."
     //  TODO: Consider adding this to the getCandyMachineV2Config schema?
@@ -371,7 +381,7 @@ programCommand('init_empty_machine')
       address: PublicKey;
       verified: boolean;
       share: number;
-    }[] = creatorsDelimited.split(";").map(creatorConf => creatorConf.split[","]).map(creatorConfSegments => {
+    }[] = creatorsDelimited.split(';').map(creatorConf => creatorConf.split(',')).map(creatorConfSegments => {
       return {
         address: new PublicKey(creatorConfSegments[0]),
         verified: creatorConfSegments[1] as boolean,

--- a/js/packages/cli/src/candy-machine-v2-cli.ts
+++ b/js/packages/cli/src/candy-machine-v2-cli.ts
@@ -372,7 +372,6 @@ programCommand('init_empty_machine')
       creatorsDelimited
     } = cmd.opts();
 
-    log.info(creatorsDelimited)
 
 
     // e.g. --creators "{address},{verified},{share};..."
@@ -385,7 +384,7 @@ programCommand('init_empty_machine')
       return {
         address: new PublicKey(creatorConfSegments[0]),
         verified: creatorConfSegments[1] as boolean,
-        share: creatorConfSegments[2] as number
+        share: Number(creatorConfSegments[2])
       }
     })
 
@@ -407,8 +406,10 @@ programCommand('init_empty_machine')
       uuid,
     } = await getCandyMachineV2Config(walletKeyPair, anchorProgram, configPath);
 
+    log.info(JSON.stringify(creators))
 
-    if (!hiddenSettings || !hiddenSettings.hash || hiddenSettings.name || !hiddenSettings.uri) {
+
+    if (!hiddenSettings || !hiddenSettings.hash || !hiddenSettings.name || !hiddenSettings.uri) {
       /**
        * When initializing an empty metadata collection, there is no metadata pre-allocation and so
        * hidden settings must be configured for the NFTs, once minted, to have resolvable metadata 

--- a/js/packages/cli/src/candy-machine-v2-cli.ts
+++ b/js/packages/cli/src/candy-machine-v2-cli.ts
@@ -351,7 +351,7 @@ programCommand('init_empty_machine')
     '--creators',
     'e.g. --creators "{creator1Address},{creator1Verified},{creator1Share};{creator2Address},{creator2Verified},{creator2Share};...etc',
   )
-  .action(async (cmd) => {
+  .action(async (args, cmd) => {
     const {
       keypair,
       env,

--- a/js/packages/cli/src/candy-machine-v2-cli.ts
+++ b/js/packages/cli/src/candy-machine-v2-cli.ts
@@ -414,6 +414,7 @@ programCommand('init_empty_machine')
     try {
 
       await initializeCandyMachine(
+        anchorProgram,
         setCollectionMint ? {
           collectionMintPubkey: await parseCollectionMintPubkey(
             collectionMint,

--- a/js/packages/cli/src/commands/upload.ts
+++ b/js/packages/cli/src/commands/upload.ts
@@ -30,26 +30,25 @@ import { pinataUpload } from '../helpers/upload/pinata';
 import { setCollection } from './set-collection';
 import { nftStorageUploadGenerator } from '../helpers/upload/nft-storage';
 
-
 /**
- * 
+ *
  * @param setCollectionMint if undefined collection mint will not be set.
- * @param payerWallet 
- * @param treasuryWallet 
- * @param splToken 
- * @param itemsAvailable 
- * @param uuid 
- * @param symbol 
- * @param sellerFeeBasisPoints 
- * @param isMutable 
- * @param maxSupply 
- * @param retainAuthority 
- * @param gatekeeper 
- * @param goLiveDate 
- * @param price 
- * @param endSettings 
- * @param whitelistMintSettings 
- * @param hiddenSettings 
+ * @param payerWallet
+ * @param treasuryWallet
+ * @param splToken
+ * @param itemsAvailable
+ * @param uuid
+ * @param symbol
+ * @param sellerFeeBasisPoints
+ * @param isMutable
+ * @param maxSupply
+ * @param retainAuthority
+ * @param gatekeeper
+ * @param goLiveDate
+ * @param price
+ * @param endSettings
+ * @param whitelistMintSettings
+ * @param hiddenSettings
  * @returns {uuid: string, candyMachine: PublicKey, collectionMetadata: string | undefined}. Collection is undefined if not set with "setCollectionMint"
  */
 export async function initializeCandyMachine(
@@ -76,8 +75,8 @@ export async function initializeCandyMachine(
   whitelistMintSettings: null | {
     mode: WhitelistMintMode;
     mint: web3.PublicKey;
-    presale: boolean,
-    discountPrice: null | BN,
+    presale: boolean;
+    discountPrice: null | BN;
   },
   hiddenSettings: null | {
     name: string;
@@ -88,10 +87,12 @@ export async function initializeCandyMachine(
     address: PublicKey;
     verified: boolean;
     share: number;
-  }[]
-
-): Promise<{ uuid: string, candyMachine: PublicKey, collectionMetadata: string | undefined }> {
-
+  }[],
+): Promise<{
+  uuid: string;
+  candyMachine: PublicKey;
+  collectionMetadata: string | undefined;
+}> {
   // initialize candy
   log.info(`initializing candy machine`);
 
@@ -118,9 +119,6 @@ export async function initializeCandyMachine(
     },
   );
 
-
-
-
   let collectionMetadata: string | undefined = undefined;
   if (setCollectionMint) {
     const collection = await setCollection(
@@ -139,9 +137,7 @@ export async function initializeCandyMachine(
     `initialized config for a candy machine with publickey: ${res.candyMachine.toBase58()}`,
   );
 
-
   return { ...res, collectionMetadata };
-
 }
 
 export async function uploadV2({
@@ -238,7 +234,6 @@ export async function uploadV2({
     : undefined;
 
   if (!cacheContent.program.uuid) {
-
     const firstAssetManifest = getAssetManifest(dirname, '0');
     if (
       !firstAssetManifest.properties?.creators?.every(
@@ -249,45 +244,46 @@ export async function uploadV2({
     }
 
     try {
-
-      const candyMachineResult: { uuid: string, candyMachine: PublicKey, collectionMetadata: string | undefined } =
-        await initializeCandyMachine(
-          anchorProgram,
-          setCollectionMint ? { collectionMintPubkey } : undefined,
-          walletKeyPair,
-          treasuryWallet,
-          splToken,
-          new BN(totalNFTs),
-          uuid,
-          firstAssetManifest.symbol,
-          firstAssetManifest.seller_fee_basis_points,
-          mutable,
-          new BN(0),
-          retainAuthority,
-          gatekeeper,
-          goLiveDate,
-          price,
-          endSettings,
-          whitelistMintSettings,
-          hiddenSettings,
-          firstAssetManifest.properties.creators.map(creator => {
-            return {
-              address: new PublicKey(creator.address),
-              verified: true,
-              share: creator.share,
-            };
-          })
-        );
+      const candyMachineResult: {
+        uuid: string;
+        candyMachine: PublicKey;
+        collectionMetadata: string | undefined;
+      } = await initializeCandyMachine(
+        anchorProgram,
+        setCollectionMint ? { collectionMintPubkey } : undefined,
+        walletKeyPair,
+        treasuryWallet,
+        splToken,
+        new BN(totalNFTs),
+        uuid,
+        firstAssetManifest.symbol,
+        firstAssetManifest.seller_fee_basis_points,
+        mutable,
+        new BN(0),
+        retainAuthority,
+        gatekeeper,
+        goLiveDate,
+        price,
+        endSettings,
+        whitelistMintSettings,
+        hiddenSettings,
+        firstAssetManifest.properties.creators.map(creator => {
+          return {
+            address: new PublicKey(creator.address),
+            verified: true,
+            share: creator.share,
+          };
+        }),
+      );
 
       cacheContent.program = {
         uuid: candyMachineResult.uuid,
         candyMachine: candyMachineResult.candyMachine.toBase58(),
-        collection: candyMachineResult.collectionMetadata
+        collection: candyMachineResult.collectionMetadata,
       };
       candyMachine = candyMachineResult.candyMachine;
 
       saveCache(cacheName, env, cacheContent);
-
     } catch (exx) {
       log.error('Error deploying config to Solana network.', exx);
       throw exx;
@@ -298,9 +294,6 @@ export async function uploadV2({
     );
   }
 
-
-
-
   const uploadedItems = Object.values(cacheContent.items).filter(
     (f: { link: string }) => !!f.link,
   ).length;
@@ -309,7 +302,8 @@ export async function uploadV2({
 
   if (dedupedAssetKeys.length) {
     log.info(
-      `Starting upload for [${dedupedAssetKeys.length
+      `Starting upload for [${
+        dedupedAssetKeys.length
       }] items, format ${JSON.stringify(dedupedAssetKeys[0])}`,
     );
   }
@@ -683,7 +677,8 @@ async function writeIndices({
     .for(poolArray)
     .handleError(async (err, { index, configLines }) => {
       log.error(
-        `\nFailed writing indices ${index}-${keys[configLines[configLines.length - 1]]
+        `\nFailed writing indices ${index}-${
+          keys[configLines[configLines.length - 1]]
         }: ${err.message}`,
       );
       await sleep(5000);

--- a/js/packages/cli/test/run-test-v2.sh
+++ b/js/packages/cli/test/run-test-v2.sh
@@ -532,9 +532,9 @@ cat >$CONFIG_FILE_EMPTY_MACHINE <<-EOM
     "endSettings": null,
     "whitelistMintSettings": null,
     "hiddenSettings": {
-		"name":"test-hidden",
-		"uri":"https://127.0.0.1/",
-		"hash":"$(md5sum "https://127.0.0.1/{tokenIndex}")"
+		"name": "test-hidden",
+		"uri": "https://127.0.0.1/",
+		"hash": "$(echo -n https://127.0.0.1/{tokenIndex} | md5sum | awk '{print $1}')"
 	},
     "noRetainAuthority": false,
     "noMutable": false

--- a/js/packages/cli/test/run-test-v2.sh
+++ b/js/packages/cli/test/run-test-v2.sh
@@ -519,6 +519,8 @@ function upload {
     fi
 }
 
+CONFIG_FILE_EMPTY_MACHINE="config-empty-machine.json"
+
 # NOTE: Using a uri template as a hash, so that the hash still offers proof for a composed metadata URI, and yet can be generated in advance of minting without an arduous task to hash all permutations. 
 cat >$CONFIG_FILE_EMPTY_MACHINE <<-EOM
 {


### PR DESCRIPTION

Draft MR Proposing Support for Empty Collections. Per Discussion:  

https://github.com/metaplex-foundation/metaplex/discussions/2168

e.g. 

```
ts-node ~/metaplex/js/packages/cli/src/candy-machine-v2-cli.ts init_empty_machine -e devnet -k {pathTo}/keypair.json -cp config.json -c {collectionName} --symbol {symbol}--seller-fee-basis-points {basisPoints} --creators-delimited "{wallet1Of2},true,50;{wallet2Of2},true,50;"
```