### PR TITLE
Reduce default batchSize of arweave-bundle to make stable upload

### DIFF
--- a/js/packages/cli/src/helpers/upload/arweave-bundle.ts
+++ b/js/packages/cli/src/helpers/upload/arweave-bundle.ts
@@ -646,7 +646,7 @@ export async function* makeArweaveBundleUploadGenerator(
       progressBar.start(bundlrTransactions.length, 0);
 
       let errored = false;
-      await PromisePool.withConcurrency(batchSize || 20)
+      await PromisePool.withConcurrency(batchSize || 5)
         .for(bundlrTransactions)
         .handleError(async err => {
           if (!errored) {


### PR DESCRIPTION
Our team tried to upload a collection that includes about 7000 NFTs using Candy Machine v2. We run `upload` again and again, but it failed due to a timeout error of bundlr.

We considered why the timeout errors happened and found that reducing `batchSize` make it work well and stable. Therefore, we suggest reducing the default batchSize from 20 to 5.