### PR TITLE
fixed null initialization type errors that intermittently pop up

### DIFF
--- a/js/packages/candy-machine-ui/src/Home.tsx
+++ b/js/packages/candy-machine-ui/src/Home.tsx
@@ -8,6 +8,7 @@ import Alert from '@material-ui/lab/Alert';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
 import {
+  AccountInfo,
   Commitment,
   Connection,
   PublicKey,
@@ -373,7 +374,7 @@ const Home = (props: HomeProps) => {
         );
 
         let status: any = { err: true };
-        let metadataStatus = null;
+        let metadataStatus: AccountInfo<Buffer> | null = null;
         if (mintResult) {
           status = await awaitTransactionSignatureConfirmation(
             mintResult.mintTxId,

--- a/js/packages/candy-machine-ui/src/candy-machine.ts
+++ b/js/packages/candy-machine-ui/src/candy-machine.ts
@@ -5,6 +5,8 @@ import {
   SystemProgram,
   Transaction,
   SYSVAR_SLOT_HASHES_PUBKEY,
+  PublicKey,
+  TransactionInstruction,
 } from '@solana/web3.js';
 import { sendTransactions, SequenceType } from './connection';
 
@@ -370,8 +372,8 @@ export const mintOneToken = async (
     : payer;
 
   const candyMachineAddress = candyMachine.id;
-  const remainingAccounts = [];
-  const instructions = [];
+  const remainingAccounts: { pubkey: PublicKey, isWritable: boolean, isSigner: boolean }[] = [];
+  const instructions: TransactionInstruction[] = []
   const signers: anchor.web3.Keypair[] = [];
   console.log('SetupState: ', setupState);
   if (!setupState) {

--- a/js/packages/candy-machine-ui/src/candy-machine.ts
+++ b/js/packages/candy-machine-ui/src/candy-machine.ts
@@ -340,7 +340,7 @@ export const createAccountsForMint = async (
         [signers],
         SequenceType.StopOnFailure,
         'singleGossip',
-        () => {},
+        () => { },
         () => false,
         undefined,
         [],
@@ -372,7 +372,11 @@ export const mintOneToken = async (
     : payer;
 
   const candyMachineAddress = candyMachine.id;
-  const remainingAccounts: { pubkey: PublicKey, isWritable: boolean, isSigner: boolean }[] = [];
+  const remainingAccounts: {
+    pubkey: PublicKey,
+    isWritable: boolean,
+    isSigner: boolean
+  }[] = [];
   const instructions: TransactionInstruction[] = []
   const signers: anchor.web3.Keypair[] = [];
   console.log('SetupState: ', setupState);
@@ -574,7 +578,7 @@ export const mintOneToken = async (
         signersMatrix,
         SequenceType.StopOnFailure,
         'singleGossip',
-        () => {},
+        () => { },
         () => false,
         undefined,
         beforeTransactions,

--- a/js/packages/candy-machine-ui/src/candy-machine.ts
+++ b/js/packages/candy-machine-ui/src/candy-machine.ts
@@ -340,7 +340,7 @@ export const createAccountsForMint = async (
         [signers],
         SequenceType.StopOnFailure,
         'singleGossip',
-        () => { },
+        () => {},
         () => false,
         undefined,
         [],
@@ -373,11 +373,11 @@ export const mintOneToken = async (
 
   const candyMachineAddress = candyMachine.id;
   const remainingAccounts: {
-    pubkey: PublicKey,
-    isWritable: boolean,
-    isSigner: boolean
+    pubkey: PublicKey;
+    isWritable: boolean;
+    isSigner: boolean;
   }[] = [];
-  const instructions: TransactionInstruction[] = []
+  const instructions: TransactionInstruction[] = [];
   const signers: anchor.web3.Keypair[] = [];
   console.log('SetupState: ', setupState);
   if (!setupState) {
@@ -578,7 +578,7 @@ export const mintOneToken = async (
         signersMatrix,
         SequenceType.StopOnFailure,
         'singleGossip',
-        () => { },
+        () => {},
         () => false,
         undefined,
         beforeTransactions,

--- a/js/packages/candy-machine-ui/src/connection.tsx
+++ b/js/packages/candy-machine-ui/src/connection.tsx
@@ -65,7 +65,7 @@ export async function sendTransactionsWithManualRetry(
 ): Promise<(string | undefined)[]> {
   let stopPoint = 0;
   let tries = 0;
-  let lastInstructionsLength = null;
+  let lastInstructionsLength: null | number = null;
   let toRemoveSigners: Record<number, boolean> = {};
   instructions = instructions.filter((instr, i) => {
     if (instr.length > 0) {


### PR DESCRIPTION
I've intermittently experienced type errors when building.
Example:
`Type 'AccountInfo<Buffer> | null' is not assignable to type 'null'.` on Home.tsx:385:11